### PR TITLE
bump up submoduled pybind11 to 2.11.1 from 2.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.5)
 project(ChiQ)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 # include guard
-cmake_minimum_required(VERSION 3.4)
 if (${CMAKE_PROJECT_NAME} STREQUAL "Project")
     message(FATAL_ERROR "cmake should be executed not for 'src' subdirectory, but for the top directory of ChiQ.")
 endif (${CMAKE_PROJECT_NAME} STREQUAL "Project")

--- a/tests/c++/CMakeLists.txt
+++ b/tests/c++/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
 include(EnableGtests) #defined in ./cmake
 set(test_src
   blockmatrixTest


### PR DESCRIPTION
The latest CMake drops the support of CMake 3.4 (in other words, if `cmake_minimum_required(VERSION 3.4)`, `cmake` fails).
This PR bumps up the used pybind11 to 2.11.x, the first version requires CMake 3.5.