### PR TITLE
Add NumPy solver backend (Phase 0 toward GPU/IR)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ ChiQ solves the Bethe-Salpeter equation (BSE) within DMFT and computes momentum-
 
 ## Build
 
-CMake-based, C++11 + Eigen3, with a pybind11 submodule (`extern/pybind11` — run `git submodule init && git submodule update` after cloning). Build out of source:
+CMake-based, C++17 + Eigen3 (modern Eigen 3.4+ requires ≥ C++14), with a pybind11 submodule (`extern/pybind11` — run `git submodule init && git submodule update` after cloning). Build out of source:
 
 ```bash
 mkdir build && cd build
@@ -45,7 +45,8 @@ Two layers connected through pybind11:
 2. **Python layer** (`python/`):
    - `python/package/chiq/` — the `chiq` package: HDF5 I/O (`h5bse.py`, all data flows through an HDF5 file produced by DCore), TOML input parsing (`bse_toml.py`), lattice Green's function / χ₀ machinery (`sumk_dft_chi.py`), SCL core (`g2scl_core.py`), point-group symmetry data (`point_group.py`, `point_group_data/`), and an MPI shim (`mpi.py` falls back to `_no_mpi.py` when mpi4py is absent).
    - `python/package/bse` is a **symlink** to `chiq` kept for backward compatibility (the install step also creates it) — never edit files through the `bse` path.
-   - `python/scripts/` — user-facing CLI entry points, installed to `bin`. Main pipeline: `gen_qpath.py` (q-path generation) → `dcore_chiq.py` (compute χ₀ and vertex from DCore output) → `chiq_main.py` (MPI-parallel solver; imports `bse_solver` C++ module) → `chiq_post.py` (eigenvalue/matrix-element post-processing; imports `chiq_main` from the same directory) → `plot_chiq_path.py`.
+   - `python/package/chiq/solver/` — the solver backend switch. `get_solver(backend, ...)` returns a `set`/`calc`/`get` facade for `backend ∈ {"cpp", "numpy", "cupy"}` (selected via `[chiq_main] backend`, default `"cpp"`). `cpp.py` wraps the pybind `bse_solver` module; `numpy.py`+`kernels.py`+`layout.py` are a pure-NumPy reimplementation that reproduces the C++ results (validated by `tests/python/non-mpi/solver/test_backend_agreement.py`); `cupy.py` is a skeleton for a future GPU backend.
+   - `python/scripts/` — user-facing CLI entry points, installed to `bin`. Main pipeline: `gen_qpath.py` (q-path generation) → `dcore_chiq.py` (compute χ₀ and vertex from DCore output) → `chiq_main.py` (MPI-parallel driver; constructs the solver via `chiq.solver.get_solver`) → `chiq_post.py` (eigenvalue/matrix-element post-processing; imports `chiq_main` from the same directory) → `plot_chiq_path.py`.
 
 The end-to-end DCore → ChiQ workflow is demonstrated in `examples/*/run.sh` (e.g. `examples/square_bse/`), and input is a TOML file with `[chiq_common]`, `[chiq_main]`, `[chiq_post]` sections.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What ChiQ is
+
+ChiQ solves the Bethe-Salpeter equation (BSE) within DMFT and computes momentum-dependent susceptibilities χ(q, iν_m) for correlated electron systems. It runs as a post-processing step of [DCore](https://github.com/issp-center-dev/DCore) and supports several approximation schemes: BSE, SCL, RPA, and RRPA (defined in `doc/algorithms.rst`).
+
+## Build
+
+CMake-based, C++11 + Eigen3, with a pybind11 submodule (`extern/pybind11` — run `git submodule init && git submodule update` after cloning). Build out of source:
+
+```bash
+mkdir build && cd build
+cmake .. -DTesting=ON -DCMAKE_INSTALL_PREFIX=$HOME/local
+make
+make install   # optional
+```
+
+- If Eigen3 isn't found: `-DEIGEN3_DIR=/path/to/eigen3-prefix`.
+- After building, `source ./chiqvars.sh` (generated in the build dir) to set PATH/PYTHONPATH for running scripts and tests against the build tree.
+
+## Tests
+
+- **C++ tests** (googletest, bundled in `tests/c++/`): run `ctest -V` (or `make test`) in the build directory. Requires `-DTesting=ON`.
+- **Python tests**: run `pytest` from the build directory (CMake copies `tests/python/` there and writes a `pytest.ini` that puts `python/package` on `pythonpath`). Requires the built `bse_solver` module to be importable — source `chiqvars.sh` first.
+  - Single test: `pytest tests/python/non-mpi/bsetool_BSE/test_bsetool_BSE.py`
+  - MPI tests live in `tests/python/mpi/`, non-MPI in `tests/python/non-mpi/`. Test dirs are named per scheme (`bsetool_BSE`, `bsetool_RPA`, `bsetool_SCL`, `bsetool_RRPA`, ...), each with its own `bse.toml` input and reference data.
+- CI (`.github/workflows/main.yml`) mirrors this exactly: cmake → make → `source ./chiqvars.sh` → `ctest -V` → `pytest`. Python deps used in CI: `mpi4py dcore more-itertools pytest`; system deps: `hdf5-tools libeigen3-dev openmpi`.
+
+## Documentation
+
+Sphinx docs in `doc/` (needs `sphinx wild_sphinx_theme matplotlib`):
+```bash
+sphinx-build -b html doc built_doc
+```
+Docs deploy automatically to gh-pages on pushes to `main`/`develop` and `*-autodoc` branches.
+
+## Architecture
+
+Two layers connected through pybind11:
+
+1. **C++ core** (`src/`): the numerical BSE solver. `bse.hpp` holds the solver logic, `block_matrix.hpp` a block-diagonal matrix type. Only a Python module is built (`bse_solver` via `bse_solver_pybind.cpp`) — the standalone C++ executable is commented out in `src/CMakeLists.txt`.
+
+2. **Python layer** (`python/`):
+   - `python/package/chiq/` — the `chiq` package: HDF5 I/O (`h5bse.py`, all data flows through an HDF5 file produced by DCore), TOML input parsing (`bse_toml.py`), lattice Green's function / χ₀ machinery (`sumk_dft_chi.py`), SCL core (`g2scl_core.py`), point-group symmetry data (`point_group.py`, `point_group_data/`), and an MPI shim (`mpi.py` falls back to `_no_mpi.py` when mpi4py is absent).
+   - `python/package/bse` is a **symlink** to `chiq` kept for backward compatibility (the install step also creates it) — never edit files through the `bse` path.
+   - `python/scripts/` — user-facing CLI entry points, installed to `bin`. Main pipeline: `gen_qpath.py` (q-path generation) → `dcore_chiq.py` (compute χ₀ and vertex from DCore output) → `chiq_main.py` (MPI-parallel solver; imports `bse_solver` C++ module) → `chiq_post.py` (eigenvalue/matrix-element post-processing; imports `chiq_main` from the same directory) → `plot_chiq_path.py`.
+
+The end-to-end DCore → ChiQ workflow is demonstrated in `examples/*/run.sh` (e.g. `examples/square_bse/`), and input is a TOML file with `[chiq_common]`, `[chiq_main]`, `[chiq_post]` sections.
+
+## Conventions
+
+- Version string lives in `python/package/chiq/__init__.py` (`__version__`).
+- CI tests Python 3.8 and 3.13 — keep the Python code compatible with 3.8 (no 3.9+-only syntax).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ChiQ)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ omega_q = "q_path.dat"
 [chiq_main]
 work_dir = "work/chiq_main"
 # num_wf = 20  # If not specified, the value is determined from X_loc
+# backend = "cpp"  # solver backend: "cpp" (default), "numpy", or "cupy" (not yet enabled)
 
 [chiq_post]
 output_dir = ""

--- a/doc/programs/chiq_main.rst
+++ b/doc/programs/chiq_main.rst
@@ -10,7 +10,7 @@ chiq_main
 Description
 -----------
 
-``chiq_main.py`` is a main script for solving the Bethe-Salpeter equation. MPI-based parallel computation is supported. A shared library implemented in C++ is called internally.
+``chiq_main.py`` is a main script for solving the Bethe-Salpeter equation. MPI-based parallel computation is supported. The solver backend is selected by the ``backend`` option in the ``[chiq_main]`` section (see :ref:`input`): ``"cpp"`` (default) calls the compiled C++ shared library, ``"numpy"`` uses an equivalent pure-Python implementation, and ``"cupy"`` is reserved for a future GPU backend.
 
 Positional Arguments
 ---------------------

--- a/doc/reference/input.rst
+++ b/doc/reference/input.rst
@@ -22,6 +22,7 @@ Below is a template of the input file.
     [chiq_main]
     work_dir = "work/chiq"
     # num_wf = 20  # If not specified, the value is determined from X_loc
+    # backend = "cpp"  # solver backend: "cpp" (default), "numpy", or "cupy"
 
     [chiq_post]
     output_dir = ""
@@ -61,6 +62,7 @@ The ``[chiq_common]`` section contains general settings that apply to both progr
 
    "work_dir", "string", ``""``, "Working directory where intermediate files are stored. The empty string (default value) means the current directory."
    "num_wf", "int", "Not specified", "Number of fermionic Matsubara frequencies. If not specified, num_wf is determined from X_loc in the input HDF5 file. num_wf can be smaller than the actual number of Matsubara frequencies in the input file."
+   "backend", "string", ``"cpp"``, "Solver backend. ``""cpp""`` (default) uses the compiled C++ solver and is recommended for production. ``""numpy""`` is a pure-Python/NumPy reimplementation that reproduces the C++ results (useful for debugging or compiler-free environments) but is single-threaded and typically several times to ~20x slower per solve (heaviest for the inversion-based ``bse``/``scl``/``rrpa`` schemes; see ``tests/python/non-mpi/solver/benchmark_backends.py``). ``""cupy""`` is reserved for a future GPU backend and is not yet enabled."
 
 [chiq_post] section
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -727,6 +727,8 @@ SET_LAYOUT = {
     "chi_loc": "C", "chi0_loc": "C", "chi0_q": "C", "gamma0": "C", "Phi_sum": "C",
 }
 CALC_TYPES = {"chi0", "bse", "rpa", "rrpa", "scl"}
+# valid get() output names (from bse_solver_pybind.cpp getMatrix)
+GET_NAMES = {"chi0_q", "chi_q", "chi_q_rpa", "chi_q_rrpa", "chi_q_scl", "I_q", "I_q_scl"}
 
 
 class SolverBase(abc.ABC):
@@ -952,7 +954,7 @@ def calc_chi0(state, beta, nb, nw, n_in):
 import numpy as np
 
 from . import kernels
-from .base import SolverBase, SET_LAYOUT, CALC_TYPES
+from .base import SolverBase, SET_LAYOUT, CALC_TYPES, GET_NAMES
 from .layout import parse_matrix_info
 
 # internal require-names used in the C++ error strings (bse.hpp)
@@ -1005,6 +1007,10 @@ class NumpySolver(SolverBase):
             self._out["I_q"] = result["I_q_scl"]
 
     def get(self, name):
+        # unknown output name -> RuntimeError (match C++ getMatrix); valid but
+        # not-yet-computed -> {}
+        if name not in GET_NAMES:
+            raise RuntimeError(f"Invalid type '{name}'")
         return self._out.get(name, {})
 ```
 

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -814,11 +814,11 @@ add a `backend` key:
 
 ```python
 # in the chiq_main section parsing of bse_toml.load_params_from_toml
-dict_tool["backend"] = dict_main.get("backend", "cpp")
+dict_tool["backend"] = params.pop("backend", "cpp")  # pop before _check_if_dict_empty
 if str(dict_tool["backend"]).lower() not in ("cpp", "numpy", "cupy"):
-    raise ValueError(
-        f"[chiq_main] backend must be 'cpp', 'numpy', or 'cupy', got "
-        f"{dict_tool['backend']!r}"
+    sys.exit(  # clean CLI exit, matching _check_if_dict_empty convention
+        f"ERROR: [chiq_main] backend must be 'cpp', 'numpy', or 'cupy', "
+        f"got {dict_tool['backend']!r}"
     )
 ```
 

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -958,7 +958,7 @@ from .base import SolverBase, SET_LAYOUT, CALC_TYPES, GET_NAMES
 from .layout import parse_matrix_info
 
 # internal require-names used in the C++ error strings (bse.hpp)
-_REQUIRE_NAME = {"X0_loc": "X0_Loc"}  # others equal their set name
+_REQUIRE_NAME = {"X0_loc": "X0_Loc", "Phi_sum": "Phi_Sum"}  # C++ internal names (bse.hpp); others equal their set name
 
 # calc_type -> list of required set names (from bse.hpp require() calls)
 _REQUIRED = {

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -1342,10 +1342,17 @@ def _assert_agree(a, b):
             va, vb = a[k], np.zeros_like(a[k])
         else:
             va, vb = np.zeros_like(b[k]), b[k]
-        # NaN / signed-inf position masks, then elementwise mixed tolerance
-        assert np.array_equal(np.isnan(va), np.isnan(vb))
-        assert np.array_equal(np.isposinf(va), np.isposinf(vb))
-        assert np.array_equal(np.isneginf(va), np.isneginf(vb))
+        # NaN / signed-inf position masks, then elementwise mixed tolerance.
+        # np.isposinf/np.isneginf reject complex dtype, so check real/imag parts
+        # separately (a test-harness detail, not a loosening of the metric).
+        va_r, va_i = np.real(va), np.imag(va)
+        vb_r, vb_i = np.real(vb), np.imag(vb)
+        assert np.array_equal(np.isnan(va_r), np.isnan(vb_r))
+        assert np.array_equal(np.isnan(va_i), np.isnan(vb_i))
+        assert np.array_equal(np.isposinf(va_r), np.isposinf(vb_r))
+        assert np.array_equal(np.isposinf(va_i), np.isposinf(vb_i))
+        assert np.array_equal(np.isneginf(va_r), np.isneginf(vb_r))
+        assert np.array_equal(np.isneginf(va_i), np.isneginf(vb_i))
         np.testing.assert_allclose(va, vb, rtol=1e-8, atol=1e-10, equal_nan=True)
 
 def _c_blocks(nb, n_in):

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -626,19 +626,19 @@ def convert_a2b(bm, nb, nw, n_in):
 
 def convert_b2a(bm, nb, nw, n_in):
     """B-type -> A-type. Emits (b1,b2) iff its assembled A block is not
-    exactly zero (matches Convert_B2A isZero(0) pruning)."""
+    exactly zero (matches Convert_B2A isZero(0) pruning — gate on the
+    assembled VALUE, not on input key presence: matmul can produce a
+    present-but-exactly-zero B block via cancellation)."""
     out = {}
     for b1 in range(nb):
         for b2 in range(nb):
             r = np.zeros((n_in, nw, n_in, nw), dtype=complex)
-            any_nonzero = False
             for iw1 in range(nw):
                 for iw2 in range(nw):
                     key = (iw1 * nb + b1, iw2 * nb + b2)
                     if key in bm:
                         r[:, iw1, :, iw2] = bm[key]
-                        any_nonzero = True
-            if any_nonzero:
+            if np.any(r != 0):
                 out[(b1, b2)] = r.reshape(n_in * nw, n_in * nw)
     return out
 

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -1,0 +1,1556 @@
+# NumPy Solver Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `backend = "cpp" | "numpy" | "cupy"` switch to the ChiQ BSE solver, with a NumPy backend that numerically matches the existing C++ backend, so later phases can add a CuPy/GPU backend and IR basis without touching driver logic.
+
+**Architecture:** A new `chiq.solver` subpackage with three separated concerns — `layout` (block-dict ↔ dense block-matrix algebra, the sole owner of the A/B/C index conventions), `kernels` (the five susceptibility calculations written against an injected array module `xp`), and a stateful `set`/`calc`/`get` facade (`CppSolver` wrapping the existing pybind module, `NumpySolver` running the kernels, `CupySolver` skeleton). `chiq_main.py` obtains its solver only through a factory.
+
+**Tech Stack:** Python ≥3.10, NumPy, the existing pybind11 module `bse_solver`, pytest. The block-matrix data model is `dict[(int,int) -> np.ndarray(complex128)]`.
+
+## Global Constraints
+
+- **Zero behavior change by default.** Default backend is `cpp`; existing runs/outputs are unchanged. `chiq_main.py` currently constructs `bse_solver.BSESolver` inline — after Task 7 it goes through `chiq.solver.get_solver`, and the `cpp` path must be byte-for-byte equivalent.
+- **Compatibility target = mathematical equivalence within tolerance**, not bitwise. Agreement metric (Task 12): elementwise `np.testing.assert_allclose(numpy, cpp, rtol=1e-8, atol=1e-10, equal_nan=True)` per block, preceded by exact NaN and signed-infinity position masks.
+- **The NumPy kernels mirror the C++ operation sequence verbatim** (explicit `block_inverse` then `matmul` wherever `bse.hpp` writes `inverse(...) * ...`), to agree with the C++ oracle at the tolerance above. The `solve`-instead-of-`inverse` optimization from the spec §3.5 is deferred to the later CuPy/performance phase.
+- **Uniform-dimension invariant:** every block has the same inner dimension `n_in` and frequency count `nw` (`chiq_main.py:524-526`; `sumk_dft_chi.py:579-580`). The layout module requires this and raises on non-uniform matrix-info. Heterogeneous blocks are unsupported.
+- **dtype:** inputs normalized to `complex128` on `set`; `get` returns `complex128`.
+- **Backend names accepted by `calc`** are case-tolerant: `"BSE"|"bse"`, `"RPA"|"rpa"`, `"RRPA"|"rrpa"`, `"SCL"|"scl"`, `"chi0"`.
+- **`get` before compute returns `{}`** (empty dict), never an exception. Unknown set/get/calc names raise `RuntimeError("Invalid type '<name>'")`.
+- **Missing-input error strings** use the C++ *internal* names — missing `X0_loc` reports `'X0_Loc'` (capital L); others match their set names.
+- **`I_q` and `I_q_scl` are one result slot** (both map to the single `Iq` member).
+- **Spec:** `docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md`. Packaging (§5, scikit-build-core, `_bse_solver` rename, entry points) is a **separate plan** — do not do it here; keep importing the current top-level `bse_solver` module.
+
+## File Structure
+
+- Create `python/package/chiq/solver/__init__.py` — `get_solver` factory, re-exports.
+- Create `python/package/chiq/solver/base.py` — `SolverBase` abstract facade + shared name/type tables.
+- Create `python/package/chiq/solver/layout.py` — block-matrix algebra: `parse_matrix_info`, `add/sub/scale/identity`, `connected_components`, `block_inverse`, `matmul`, `sumfreq_a`, `sumfreq_b`, `convert_a2b`, `convert_b2a`, `prod_ab`.
+- Create `python/package/chiq/solver/kernels.py` — `calc_chi0`, `calc_bse`, `calc_rpa`, `calc_rrpa`, `calc_scl`, each `(state, beta, dims) -> dict[name -> bm]`.
+- Create `python/package/chiq/solver/cpp.py` — `CppSolver`.
+- Create `python/package/chiq/solver/numpy.py` — `NumpySolver`.
+- Create `python/package/chiq/solver/cupy.py` — `CupySolver` skeleton.
+- Modify `python/scripts/chiq_main.py` — construct the solver via `get_solver`.
+- Modify `python/package/chiq/bse_toml.py` — parse+validate `[chiq_main] backend`.
+- Create tests under `tests/python/non-mpi/solver/` — unit tests for layout/kernels/facade.
+- Modify existing fixtures `tests/python/non-mpi/bsetool_{BSE,RPA,SCL,RRPA}/test_*.py` — parametrize over backend (Task 12).
+
+Layout conventions (all reproduced from `src/bse.hpp`, `src/block_matrix.hpp`):
+`nb` = number of C-vertices, `nw` = number of frequencies, `n_in` = inner dim.
+- C-type: key `b∈[0,nb)`, block `n_in×n_in`, dims `[n_in]*nb`.
+- B-type: key `iw*nb+b`, block `n_in×n_in`, dims `[n_in]*(nb*nw)`. Inputs are iw-diagonal; intermediates (from `convert_a2b`) may have cross-iw keys.
+- A-type: key `b∈[0,nb)`, block `(n_in*nw)×(n_in*nw)`, inner flattened `in*nw+iw`, dims `[n_in*nw]*nb`.
+- Missing key = structural zero.
+
+---
+
+### Task 1: layout — matrix-info parsing and validation
+
+**Files:**
+- Create: `python/package/chiq/solver/__init__.py` (empty for now: `# chiq solver subpackage`)
+- Create: `python/package/chiq/solver/layout.py`
+- Test: `tests/python/non-mpi/solver/test_layout_info.py`
+
+**Interfaces:**
+- Produces: `parse_matrix_info(info_A, info_B, info_C) -> (nb, nw, n_in)`. Raises `ValueError` on non-uniform or inconsistent info. `info_*` are sequences of ints.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_layout_info.py
+import numpy as np
+import pytest
+from chiq.solver import layout
+
+def test_parse_matrix_info_uniform():
+    nb, nw, n_in = 2, 3, 4
+    info_A = [n_in * nw] * nb
+    info_B = [n_in] * (nb * nw)
+    info_C = [n_in] * nb
+    assert layout.parse_matrix_info(info_A, info_B, info_C) == (nb, nw, n_in)
+
+def test_parse_matrix_info_rejects_nonuniform_inner():
+    with pytest.raises(ValueError):
+        layout.parse_matrix_info([8, 8], [4, 4, 5, 4], [4, 4])  # info_B not all equal
+
+def test_parse_matrix_info_rejects_bad_A_dim():
+    # nb=2, nw=2, n_in=4 -> info_A must be [8,8]; give [9,9]
+    with pytest.raises(ValueError):
+        layout.parse_matrix_info([9, 9], [4, 4, 4, 4], [4, 4])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_info.py -v`
+Expected: FAIL (module `chiq.solver.layout` has no `parse_matrix_info`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# python/package/chiq/solver/layout.py
+"""Block-matrix algebra for the ChiQ solver backends.
+
+Reproduces the A/B/C block conventions and operations of the C++ solver
+(src/bse.hpp, src/block_matrix.hpp) on dict-of-ndarray block matrices:
+    block matrix := dict[(vi, vj) -> np.ndarray(complex128)]
+Missing key == structural zero. See the design spec section 3.4-3.5.
+"""
+
+import numpy as np
+
+
+def parse_matrix_info(info_A, info_B, info_C):
+    """Return (nb, nw, n_in) from the three matrix-info vectors.
+
+    Enforces the uniform-dimension invariant (same n_in and nw for every
+    block). Raises ValueError on any non-uniform or inconsistent input.
+    """
+    info_A = list(info_A)
+    info_B = list(info_B)
+    info_C = list(info_C)
+    if not info_C:
+        raise ValueError("info_C is empty")
+    nb = len(info_C)
+    n_in = int(info_C[0])
+    if n_in <= 0:
+        raise ValueError(f"non-positive inner dimension {n_in}")
+    if any(int(x) != n_in for x in info_C):
+        raise ValueError("info_C is not uniform")
+    if len(info_B) % nb != 0:
+        raise ValueError("len(info_B) is not a multiple of nb")
+    nw = len(info_B) // nb
+    if nw <= 0:
+        raise ValueError("nw must be positive")
+    if any(int(x) != n_in for x in info_B):
+        raise ValueError("info_B is not uniform (!= n_in)")
+    if len(info_A) != nb or any(int(x) != n_in * nw for x in info_A):
+        raise ValueError("info_A inconsistent with n_in*nw")
+    return nb, nw, n_in
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_info.py -v`
+Expected: PASS (4 tests). Note: to import `chiq`, run from a tree where `python/package` is importable — source the build `chiqvars.sh`, or `PYTHONPATH=python/package python -m pytest ...`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/__init__.py python/package/chiq/solver/layout.py tests/python/non-mpi/solver/test_layout_info.py
+git commit -m "feat(solver): layout.parse_matrix_info with uniform-dim validation"
+```
+
+---
+
+### Task 2: layout — elementwise add/sub/scale and identity
+
+**Files:**
+- Modify: `python/package/chiq/solver/layout.py`
+- Test: `tests/python/non-mpi/solver/test_layout_elementwise.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `add(a, b) -> dict`, `sub(a, b) -> dict`, `scale(s, bm) -> dict`, `identity(dims) -> dict`. Block matrices are `dict[(int,int)->ndarray]`; `dims` is a sequence of per-vertex dimensions.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_layout_elementwise.py
+import numpy as np
+from chiq.solver import layout
+
+def _blk(v):
+    return np.array([[v]], dtype=complex)
+
+def test_sub_union_of_keys():
+    a = {(0, 0): _blk(3), (0, 1): _blk(2)}
+    b = {(0, 0): _blk(1), (1, 1): _blk(5)}
+    r = layout.sub(a, b)
+    assert set(r) == {(0, 0), (0, 1), (1, 1)}
+    assert r[(0, 0)] == _blk(2)
+    assert r[(0, 1)] == _blk(2)
+    assert r[(1, 1)] == _blk(-5)
+
+def test_add_and_scale():
+    a = {(0, 0): _blk(3)}
+    b = {(0, 0): _blk(1)}
+    assert layout.add(a, b)[(0, 0)] == _blk(4)
+    assert layout.scale(2.0, a)[(0, 0)] == _blk(6)
+
+def test_identity():
+    ident = layout.identity([2, 1])
+    assert set(ident) == {(0, 0), (1, 1)}
+    assert np.array_equal(ident[(0, 0)], np.eye(2, dtype=complex))
+    assert np.array_equal(ident[(1, 1)], np.eye(1, dtype=complex))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_elementwise.py -v`
+Expected: FAIL (`add`/`sub`/`scale`/`identity` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/layout.py
+
+def add(a, b):
+    """Entrywise a + b over the union of present keys."""
+    out = {}
+    for k in set(a) | set(b):
+        if k in a and k in b:
+            out[k] = a[k] + b[k]
+        elif k in a:
+            out[k] = a[k].copy()
+        else:
+            out[k] = b[k].copy()
+    return out
+
+
+def sub(a, b):
+    """Entrywise a - b over the union of present keys."""
+    out = {}
+    for k in set(a) | set(b):
+        if k in a and k in b:
+            out[k] = a[k] - b[k]
+        elif k in a:
+            out[k] = a[k].copy()
+        else:
+            out[k] = -b[k]
+    return out
+
+
+def scale(s, bm):
+    """Scalar multiply every block by s."""
+    return {k: s * v for k, v in bm.items()}
+
+
+def identity(dims):
+    """Block-diagonal identity with the given per-vertex dimensions."""
+    return {(i, i): np.eye(int(d), dtype=complex) for i, d in enumerate(dims)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_elementwise.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/layout.py tests/python/non-mpi/solver/test_layout_elementwise.py
+git commit -m "feat(solver): layout add/sub/scale/identity"
+```
+
+---
+
+### Task 3: layout — connected components and block inverse (with fill-in)
+
+**Files:**
+- Modify: `python/package/chiq/solver/layout.py`
+- Test: `tests/python/non-mpi/solver/test_layout_inverse.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `connected_components(bm, nvert) -> list[list[int]]` (components under edge `(i,j) or (j,i) present`, each component's vertices sorted, components sorted by first vertex). `block_inverse(bm, dims) -> dict` (per-component dense inverse; emits **every** intra-component vertex pair, numerical zeros retained; cross-component pairs absent).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_layout_inverse.py
+import numpy as np
+from chiq.solver import layout
+
+def test_connected_components_two_islands():
+    bm = {(0, 0): np.eye(1) * 1, (2, 2): np.eye(1) * 1, (0, 2): np.eye(1) * 0.0 + 1}
+    # vertices 0 and 2 are connected via (0,2); vertex 1 isolated
+    comps = layout.connected_components(bm, nvert=3)
+    assert comps == [[0, 2], [1]]
+
+def test_block_inverse_matches_dense_and_fills_in():
+    # single 2-vertex component; inverse is generally full within the component
+    a = np.array([[2, 1], [0, 3]], dtype=complex)
+    b = np.array([[1, 0], [1, 1]], dtype=complex)
+    c = np.array([[4, 0], [0, 2]], dtype=complex)
+    d = np.array([[1, 2], [0, 1]], dtype=complex)
+    bm = {(0, 0): a, (0, 1): b, (1, 0): c, (1, 1): d}
+    inv = layout.block_inverse(bm, dims=[2, 2])
+    # reconstruct dense 4x4 and compare
+    big = np.block([[a, b], [c, d]])
+    big_inv = np.linalg.inv(big)
+    got = np.block([[inv[(0, 0)], inv[(0, 1)]], [inv[(1, 0)], inv[(1, 1)]]])
+    assert np.allclose(got, big_inv)
+    # fill-in: all 4 intra-component pairs present
+    assert set(inv) == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+def test_block_inverse_keeps_components_separate():
+    bm = {(0, 0): np.array([[2]], dtype=complex), (1, 1): np.array([[4]], dtype=complex)}
+    inv = layout.block_inverse(bm, dims=[1, 1])
+    assert set(inv) == {(0, 0), (1, 1)}
+    assert np.allclose(inv[(0, 0)], [[0.5]])
+    assert np.allclose(inv[(1, 1)], [[0.25]])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_inverse.py -v`
+Expected: FAIL (`connected_components`/`block_inverse` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/layout.py
+
+def connected_components(bm, nvert):
+    """Connected components of the block-sparsity graph.
+
+    Edge between i and j iff (i,j) or (j,i) is a present key (matches
+    block_matrix.hpp `connected`). Returns a list of components, each a
+    sorted list of vertices, components sorted by their first vertex.
+    """
+    adj = {i: set() for i in range(nvert)}
+    for (i, j) in bm:
+        adj[i].add(j)
+        adj[j].add(i)
+    seen = [False] * nvert
+    comps = []
+    for start in range(nvert):
+        if seen[start]:
+            continue
+        stack = [start]
+        seen[start] = True
+        comp = []
+        while stack:
+            v = stack.pop()
+            comp.append(v)
+            for w in adj[v]:
+                if not seen[w]:
+                    seen[w] = True
+                    stack.append(w)
+        comps.append(sorted(comp))
+    comps.sort(key=lambda c: c[0])
+    return comps
+
+
+def block_inverse(bm, dims):
+    """Per-connected-component dense inverse.
+
+    Assembles each component into a dense super-block, inverts it, and
+    scatters back every intra-component vertex pair (dense fill-in,
+    numerical zeros retained), matching block_matrix.hpp `inverse`.
+    """
+    dims = [int(d) for d in dims]
+    nvert = len(dims)
+    out = {}
+    for comp in connected_components(bm, nvert):
+        offsets = {}
+        size = 0
+        for v in comp:
+            offsets[v] = size
+            size += dims[v]
+        super_block = np.zeros((size, size), dtype=complex)
+        for a in comp:
+            for b in comp:
+                if (a, b) in bm:
+                    super_block[offsets[a]:offsets[a] + dims[a],
+                                offsets[b]:offsets[b] + dims[b]] = bm[(a, b)]
+        with np.errstate(divide="ignore", invalid="ignore"):
+            try:
+                inv = np.linalg.inv(super_block)
+            except np.linalg.LinAlgError:
+                inv = np.full((size, size), np.nan, dtype=complex)
+        for a in comp:
+            for b in comp:
+                out[(a, b)] = inv[offsets[a]:offsets[a] + dims[a],
+                                  offsets[b]:offsets[b] + dims[b]].copy()
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_inverse.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/layout.py tests/python/non-mpi/solver/test_layout_inverse.py
+git commit -m "feat(solver): layout connected_components + block_inverse with fill-in"
+```
+
+---
+
+### Task 4: layout — block matrix product
+
+**Files:**
+- Modify: `python/package/chiq/solver/layout.py`
+- Test: `tests/python/non-mpi/solver/test_layout_matmul.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `matmul(a, b, dims) -> dict`. Result key `(i,j)` present **iff ∃k with `(i,k)` in `a` and `(k,j)` in `b`** (structural, value-independent, matching `block_matrix.hpp operator*`); value `Σ_k a[(i,k)] @ b[(k,j)]`. `dims` gives `nvert=len(dims)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_layout_matmul.py
+import numpy as np
+from chiq.solver import layout
+
+def test_matmul_structural_keys_and_values():
+    a = {(0, 0): np.array([[1, 2], [3, 4]], dtype=complex),
+         (0, 1): np.array([[1, 0], [0, 1]], dtype=complex)}
+    b = {(0, 0): np.array([[1, 0], [0, 1]], dtype=complex),
+         (1, 1): np.array([[2, 0], [0, 2]], dtype=complex)}
+    r = layout.matmul(a, b, dims=[2, 2])
+    # (0,0): a00@b00 ; (0,1): a01@b11 ; nothing writes (1,*)
+    assert set(r) == {(0, 0), (0, 1)}
+    assert np.allclose(r[(0, 0)], a[(0, 0)])
+    assert np.allclose(r[(0, 1)], 2 * np.eye(2))
+
+def test_matmul_noncommuting():
+    x = np.array([[0, 1], [0, 0]], dtype=complex)
+    y = np.array([[0, 0], [1, 0]], dtype=complex)
+    a = {(0, 0): x}
+    b = {(0, 0): y}
+    assert np.allclose(layout.matmul(a, b, [2])[(0, 0)], x @ y)
+    assert not np.allclose(x @ y, y @ x)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_matmul.py -v`
+Expected: FAIL (`matmul` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/layout.py
+
+def matmul(a, b, dims):
+    """Block matrix product a @ b.
+
+    Emits key (i,j) iff there exists k with (i,k) in a and (k,j) in b
+    (structural rule, matching block_matrix.hpp operator*); the numerical
+    value never decides key presence.
+    """
+    nvert = len(dims)
+    out = {}
+    for i in range(nvert):
+        for j in range(nvert):
+            acc = None
+            for k in range(nvert):
+                if (i, k) in a and (k, j) in b:
+                    p = a[(i, k)] @ b[(k, j)]
+                    acc = p if acc is None else acc + p
+            if acc is not None:
+                out[(i, j)] = acc
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_matmul.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/layout.py tests/python/non-mpi/solver/test_layout_matmul.py
+git commit -m "feat(solver): layout.matmul with structural key rule"
+```
+
+---
+
+### Task 5: layout — Sumfreq_A and Sumfreq_B
+
+**Files:**
+- Modify: `python/package/chiq/solver/layout.py`
+- Test: `tests/python/non-mpi/solver/test_layout_sumfreq.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `sumfreq_a(bm, nb, nw, n_in) -> dict` (A→C; only keys present in `bm`; `out[(i,j)][a,c] = Σ_{iw1,iw2} A[(i,j)][a*nw+iw1, c*nw+iw2]`). `sumfreq_b(bm, nb, nw, n_in) -> dict` (B→C; **all** `nb²` keys emitted; `out[(i,j)] = Σ_iw B[(iw*nb+i, iw*nb+j)]` over present keys).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_layout_sumfreq.py
+import numpy as np
+from chiq.solver import layout
+
+def test_sumfreq_b_sums_over_frequency_and_emits_all_keys():
+    nb, nw, n_in = 2, 2, 1
+    bm = {}
+    # only diagonal (i==j) same-iw keys present
+    bm[(0 * nb + 0, 0 * nb + 0)] = np.array([[1.0]], dtype=complex)
+    bm[(1 * nb + 0, 1 * nb + 0)] = np.array([[3.0]], dtype=complex)  # iw=1, b=0
+    out = layout.sumfreq_b(bm, nb, nw, n_in)
+    assert set(out) == {(i, j) for i in range(nb) for j in range(nb)}
+    assert np.allclose(out[(0, 0)], [[4.0]])  # 1 + 3
+    assert np.allclose(out[(0, 1)], [[0.0]])
+
+def test_sumfreq_a_sums_over_both_frequency_indices():
+    nb, nw, n_in = 1, 2, 1
+    # A block is (n_in*nw)=(2) x 2; inner flattened as in*nw+iw -> here in=0 so index==iw
+    A = np.array([[1, 2], [3, 4]], dtype=complex)
+    bm = {(0, 0): A}
+    out = layout.sumfreq_a(bm, nb, nw, n_in)
+    assert set(out) == {(0, 0)}
+    assert np.allclose(out[(0, 0)], [[1 + 2 + 3 + 4]])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_sumfreq.py -v`
+Expected: FAIL (`sumfreq_a`/`sumfreq_b` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/layout.py
+
+def sumfreq_a(bm, nb, nw, n_in):
+    """A-type -> C-type by summing over both frequency indices.
+
+    out[(i,j)][a,c] = sum_{iw1,iw2} A[(i,j)][a*nw+iw1, c*nw+iw2].
+    Only keys present in bm are emitted (matches Sumfreq_A which skips
+    absent A blocks).
+    """
+    out = {}
+    for (i, j), mat in bm.items():
+        r = mat.reshape(n_in, nw, n_in, nw)
+        out[(i, j)] = r.sum(axis=(1, 3))
+    return out
+
+
+def sumfreq_b(bm, nb, nw, n_in):
+    """B-type -> C-type by summing over the (diagonal) frequency index.
+
+    out[(i,j)] = sum_iw B[(iw*nb+i, iw*nb+j)] over present keys. Every
+    nb*nb key is emitted (matches Sumfreq_B, which assigns all blocks).
+    """
+    out = {}
+    for i in range(nb):
+        for j in range(nb):
+            m = np.zeros((n_in, n_in), dtype=complex)
+            for iw in range(nw):
+                key = (iw * nb + i, iw * nb + j)
+                if key in bm:
+                    m = m + bm[key]
+            out[(i, j)] = m
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_sumfreq.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/layout.py tests/python/non-mpi/solver/test_layout_sumfreq.py
+git commit -m "feat(solver): layout sumfreq_a / sumfreq_b"
+```
+
+---
+
+### Task 6: layout — Convert_A2B, Convert_B2A, prod_ab
+
+**Files:**
+- Modify: `python/package/chiq/solver/layout.py`
+- Test: `tests/python/non-mpi/solver/test_layout_convert.py`
+
+**Interfaces:**
+- Consumes: `matmul`.
+- Produces: `convert_a2b(bm, nb, nw, n_in) -> dict` (A→B; key `(iw1*nb+b1, iw2*nb+b2)` emitted iff the extracted block is not exactly zero — `isZero(0)` pruning). `convert_b2a(bm, nb, nw, n_in) -> dict` (B→A; key `(b1,b2)` emitted iff its assembled A block is not exactly zero). `prod_ab(a_mat, b_mat, nb, nw, n_in) -> dict` = `convert_b2a(matmul(convert_a2b(a_mat), b_mat, [n_in]*(nb*nw)))` (A-type result), reproducing `bse.hpp Prod_A_B`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_layout_convert.py
+import numpy as np
+from chiq.solver import layout
+
+def test_a2b_b2a_roundtrip():
+    nb, nw, n_in = 1, 2, 1
+    A = np.array([[1, 2], [3, 4]], dtype=complex)  # in*nw+iw indexing, n_in=1
+    a = {(0, 0): A}
+    b = layout.convert_a2b(a, nb, nw, n_in)
+    # keys are (iw1*nb+0, iw2*nb+0) for nonzero extracted entries
+    assert (0, 0) in b and (1, 1) in b  # A[0,0]=1, A[1,1]=4
+    back = layout.convert_b2a(b, nb, nw, n_in)
+    assert np.allclose(back[(0, 0)], A)
+
+def test_a2b_prunes_exact_zero_blocks():
+    nb, nw, n_in = 1, 2, 1
+    A = np.array([[1, 0], [0, 4]], dtype=complex)
+    b = layout.convert_a2b({(0, 0): A}, nb, nw, n_in)
+    assert set(b) == {(0, 0), (1, 1)}  # cross-freq (0,1),(1,0) are exactly zero -> pruned
+
+def test_prod_ab_matches_dense():
+    nb, nw, n_in = 1, 2, 1
+    A = np.array([[1, 2], [3, 4]], dtype=complex)
+    # B-type diagonal in iw: keys (iw,iw)
+    Bmat = {(0, 0): np.array([[2]], dtype=complex), (1, 1): np.array([[5]], dtype=complex)}
+    got = layout.prod_ab(A_as := {(0, 0): A}, Bmat, nb, nw, n_in)
+    # dense: convert A to B (full 2x2 in freq), multiply by diag(2,5), convert back
+    Bdense = np.diag([2.0, 5.0]).astype(complex)
+    assert np.allclose(got[(0, 0)], A @ Bdense)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_convert.py -v`
+Expected: FAIL (`convert_a2b`/`convert_b2a`/`prod_ab` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/layout.py
+
+def convert_a2b(bm, nb, nw, n_in):
+    """A-type -> B-type. Emits (iw1*nb+b1, iw2*nb+b2) iff the extracted
+    block is not exactly zero (matches Convert_A2B isZero(0) pruning)."""
+    out = {}
+    for (b1, b2), mat in bm.items():
+        r = mat.reshape(n_in, nw, n_in, nw)
+        for iw1 in range(nw):
+            for iw2 in range(nw):
+                block = r[:, iw1, :, iw2]
+                if np.any(block != 0):
+                    out[(iw1 * nb + b1, iw2 * nb + b2)] = block.copy()
+    return out
+
+
+def convert_b2a(bm, nb, nw, n_in):
+    """B-type -> A-type. Emits (b1,b2) iff its assembled A block is not
+    exactly zero (matches Convert_B2A isZero(0) pruning)."""
+    out = {}
+    for b1 in range(nb):
+        for b2 in range(nb):
+            r = np.zeros((n_in, nw, n_in, nw), dtype=complex)
+            any_nonzero = False
+            for iw1 in range(nw):
+                for iw2 in range(nw):
+                    key = (iw1 * nb + b1, iw2 * nb + b2)
+                    if key in bm:
+                        r[:, iw1, :, iw2] = bm[key]
+                        any_nonzero = True
+            if any_nonzero:
+                out[(b1, b2)] = r.reshape(n_in * nw, n_in * nw)
+    return out
+
+
+def prod_ab(a_mat, b_mat, nb, nw, n_in):
+    """A-type * B-type -> A-type, via convert to B, multiply, convert back
+    (reproduces bse.hpp Prod_A_B)."""
+    a_in_b = convert_a2b(a_mat, nb, nw, n_in)
+    ab_in_b = matmul(a_in_b, b_mat, [n_in] * (nb * nw))
+    return convert_b2a(ab_in_b, nb, nw, n_in)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_layout_convert.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/layout.py tests/python/non-mpi/solver/test_layout_convert.py
+git commit -m "feat(solver): layout convert_a2b/convert_b2a/prod_ab"
+```
+
+---
+
+### Task 7: SolverBase + factory + CppSolver; route chiq_main and bse_toml
+
+**Files:**
+- Create: `python/package/chiq/solver/base.py`
+- Create: `python/package/chiq/solver/cpp.py`
+- Modify: `python/package/chiq/solver/__init__.py`
+- Modify: `python/package/chiq/bse_toml.py`
+- Modify: `python/scripts/chiq_main.py:551` (solver construction) and its solver calls
+- Test: `tests/python/non-mpi/solver/test_factory_cpp.py`
+
+**Interfaces:**
+- Consumes: existing `bse_solver.BSESolver`.
+- Produces: `chiq.solver.get_solver(backend, beta, info_A, info_B, info_C) -> SolverBase`; `SolverBase` with `set(bm, name)`, `calc(calc_type)`, `get(name) -> dict`. `bse_toml.load_params_from_toml` returns a `dict_tool` that now includes `"backend"` (default `"cpp"`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_factory_cpp.py
+import numpy as np
+import pytest
+from chiq.solver import get_solver
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def test_factory_returns_cpp_by_default_and_runs_chi0():
+    nb, nw, n_in = 1, 2, 1
+    iA, iB, iC = _info(nb, nw, n_in)
+    solver = get_solver("cpp", beta=10.0, info_A=iA, info_B=iB, info_C=iC)
+    # minimal chi0 inputs
+    solver.set({(0, 0): np.zeros((n_in, n_in), dtype=complex)}, "chi0_loc")
+    solver.set({(0, 0): np.zeros((n_in, n_in), dtype=complex), (1, 1): np.zeros((n_in, n_in), dtype=complex)}, "X0_loc")
+    solver.set({(0, 0): np.zeros((n_in, n_in), dtype=complex), (1, 1): np.zeros((n_in, n_in), dtype=complex)}, "X0_q")
+    solver.calc("chi0")
+    out = solver.get("chi0_q")
+    assert isinstance(out, dict)
+
+def test_factory_rejects_unknown_backend():
+    iA, iB, iC = _info(1, 2, 1)
+    with pytest.raises(ValueError):
+        get_solver("gpu999", 10.0, iA, iB, iC)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_factory_cpp.py -v` (needs the built `bse_solver` importable — source `chiqvars.sh` from the build dir first).
+Expected: FAIL (`get_solver` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# python/package/chiq/solver/base.py
+"""Solver facade base class and shared name tables."""
+
+import abc
+
+# set-name -> layout type
+SET_LAYOUT = {
+    "X_loc": "A", "X0_loc": "B", "X0_q": "B", "Phi": "B",
+    "chi_loc": "C", "chi0_loc": "C", "chi0_q": "C", "gamma0": "C", "Phi_sum": "C",
+}
+CALC_TYPES = {"chi0", "bse", "rpa", "rrpa", "scl"}
+
+
+class SolverBase(abc.ABC):
+    def __init__(self, beta, info_A, info_B, info_C):
+        self.beta = float(beta)
+        self.info_A = list(int(x) for x in info_A)
+        self.info_B = list(int(x) for x in info_B)
+        self.info_C = list(int(x) for x in info_C)
+
+    @abc.abstractmethod
+    def set(self, bm, name):
+        ...
+
+    @abc.abstractmethod
+    def calc(self, calc_type):
+        ...
+
+    @abc.abstractmethod
+    def get(self, name):
+        ...
+```
+
+```python
+# python/package/chiq/solver/cpp.py
+"""C++ backend: thin wrapper over the pybind module `bse_solver`."""
+
+import numpy as np
+import bse_solver  # top-level pybind module (packaging phase renames to chiq._bse_solver)
+
+from .base import SolverBase
+
+
+class CppSolver(SolverBase):
+    def __init__(self, beta, info_A, info_B, info_C):
+        super().__init__(beta, info_A, info_B, info_C)
+        self._impl = bse_solver.BSESolver(
+            self.beta,
+            np.array(self.info_A),
+            np.array(self.info_B),
+            np.array(self.info_C),
+        )
+
+    def set(self, bm, name):
+        self._impl.set(bm, name)
+
+    def calc(self, calc_type):
+        self._impl.calc(calc_type)
+
+    def get(self, name):
+        return self._impl.get(name)
+```
+
+```python
+# python/package/chiq/solver/__init__.py
+"""chiq solver subpackage: backend factory."""
+
+from .base import SolverBase
+
+
+def get_solver(backend, beta, info_A, info_B, info_C):
+    """Return a solver facade for the named backend.
+
+    backend: "cpp" (default in the driver), "numpy", or "cupy".
+    """
+    name = str(backend).lower()
+    if name == "cpp":
+        from .cpp import CppSolver
+        return CppSolver(beta, info_A, info_B, info_C)
+    if name == "numpy":
+        from .numpy import NumpySolver
+        return NumpySolver(beta, info_A, info_B, info_C)
+    if name == "cupy":
+        from .cupy import CupySolver
+        return CupySolver(beta, info_A, info_B, info_C)
+    raise ValueError(
+        f"Unknown backend {backend!r}; expected one of 'cpp', 'numpy', 'cupy'."
+    )
+```
+
+Now wire the TOML parser. In `python/package/chiq/bse_toml.py`, in the function that
+builds the `[chiq_main]` tool dict (search for where `work_dir` / `num_wf` are read),
+add a `backend` key:
+
+```python
+# in the chiq_main section parsing of bse_toml.load_params_from_toml
+dict_tool["backend"] = dict_main.get("backend", "cpp")
+if str(dict_tool["backend"]).lower() not in ("cpp", "numpy", "cupy"):
+    raise ValueError(
+        f"[chiq_main] backend must be 'cpp', 'numpy', or 'cupy', got "
+        f"{dict_tool['backend']!r}"
+    )
+```
+
+(Adapt the local variable name to the existing code: `dict_main` is whatever dict holds
+the `[chiq_main]` table; `dict_tool` is the returned tool dict. If `num_wf` is read as
+`dict_tool["num_wf"] = dict_main.get("num_wf", None)`, mirror that exact pattern.)
+
+Now route `chiq_main.py`. Replace the direct construction at `chiq_main.py:551`:
+
+```python
+# OLD:
+# solver = bse_solver.BSESolver(chi_worker.beta, matinfo_A, matinfo_B, matinfo_C)
+# NEW:
+from chiq.solver import get_solver  # add near the top imports; remove `import bse_solver`
+...
+solver = get_solver(dict_tool["backend"], chi_worker.beta, matinfo_A, matinfo_B, matinfo_C)
+```
+
+The subsequent `solver.set(...)`, `solver.calc(calc_type)`, `solver.get(...)` calls are
+unchanged (the facade mirrors the pybind API). Read `backend` from the already-parsed
+`dict_tool` in `main()` (it is available where `n_iw = dict_tool["num_wf"]` is read):
+
+```python
+backend = dict_tool["backend"]
+```
+
+and thread it into the loop (or read `dict_tool["backend"]` at the `get_solver` call site).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_factory_cpp.py -v`
+Expected: PASS (2 tests).
+Run the full existing suite to confirm the refactor is behavior-preserving:
+Run: `python -m pytest tests/python/non-mpi -v`
+Expected: PASS (all previously-passing tests still pass; default backend cpp).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/base.py python/package/chiq/solver/cpp.py python/package/chiq/solver/__init__.py python/package/chiq/bse_toml.py python/scripts/chiq_main.py tests/python/non-mpi/solver/test_factory_cpp.py
+git commit -m "feat(solver): SolverBase + get_solver factory + CppSolver; route chiq_main via backend"
+```
+
+---
+
+### Task 8: kernels — chi0, and the NumpySolver facade
+
+**Files:**
+- Create: `python/package/chiq/solver/kernels.py`
+- Create: `python/package/chiq/solver/numpy.py`
+- Test: `tests/python/non-mpi/solver/test_numpy_chi0.py`, `tests/python/non-mpi/solver/test_numpy_facade.py`
+
+**Interfaces:**
+- Consumes: `layout`, `base.SET_LAYOUT`/`CALC_TYPES`.
+- Produces: `kernels.calc_chi0(state, beta, nb, nw, n_in) -> dict[name -> bm]`; `NumpySolver(SolverBase)` with `set/calc/get`, storing inputs in `self._in` (normalized complex128) and outputs in `self._out`. `set` unknown name → `RuntimeError("Invalid type '<name>'")`; missing input on `calc` → `RuntimeError("'<internal>' must be set before calling calc.")` with `X0_loc`→`'X0_Loc'`; `get` of un-computed valid name → `{}`; `get` unknown → `RuntimeError`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_numpy_facade.py
+import numpy as np
+import pytest
+from chiq.solver import get_solver
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def test_set_unknown_name_raises():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    with pytest.raises(RuntimeError, match="Invalid type"):
+        s.set({(0, 0): np.zeros((1, 1), complex)}, "nope")
+
+def test_get_before_calc_returns_empty_dict():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    assert s.get("chi0_q") == {}
+
+def test_missing_input_reports_capital_X0_Loc():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    s.set({(0, 0): np.zeros((1, 1), complex)}, "chi0_loc")
+    s.set({(0, 0): np.zeros((1, 1), complex), (1, 1): np.zeros((1, 1), complex)}, "X0_q")
+    with pytest.raises(RuntimeError, match="'X0_Loc' must be set"):
+        s.calc("chi0")
+```
+
+```python
+# tests/python/non-mpi/solver/test_numpy_chi0.py
+import numpy as np
+from chiq.solver import get_solver
+
+def test_chi0_formula_one_block():
+    # nb=1, nw=1, n_in=1, beta given; chi0_q = chi0_loc + (1/beta)*(X0_q - X0_loc)
+    beta = 4.0
+    iA, iB, iC = [1], [1], [1]
+    s = get_solver("numpy", beta, iA, iB, iC)
+    s.set({(0, 0): np.array([[7.0]], complex)}, "chi0_loc")
+    s.set({(0, 0): np.array([[2.0]], complex)}, "X0_loc")
+    s.set({(0, 0): np.array([[10.0]], complex)}, "X0_q")
+    s.calc("chi0")
+    out = s.get("chi0_q")
+    assert np.allclose(out[(0, 0)], [[7.0 + (10.0 - 2.0) / beta]])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_facade.py tests/python/non-mpi/solver/test_numpy_chi0.py -v`
+Expected: FAIL (`chiq.solver.numpy` / `kernels` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# python/package/chiq/solver/kernels.py
+"""The five susceptibility calculations on block matrices (layout ops).
+
+Each returns a dict of named output block matrices. Operation order mirrors
+src/bse.hpp verbatim (explicit block_inverse then matmul) so the results
+agree with the C++ backend within tolerance.
+"""
+
+from . import layout as L
+
+
+def calc_chi0(state, beta, nb, nw, n_in):
+    info_B = [n_in] * (nb * nw)  # noqa: F841 (documents B dims)
+    diff = L.sub(state["X0_q"], state["X0_loc"])
+    chi0_q = L.add(state["chi0_loc"], L.scale(1.0 / beta, L.sumfreq_b(diff, nb, nw, n_in)))
+    return {"chi0_q": chi0_q}
+```
+
+```python
+# python/package/chiq/solver/numpy.py
+"""NumPy backend: runs the kernels on complex128 block matrices."""
+
+import numpy as np
+
+from . import kernels
+from .base import SolverBase, SET_LAYOUT, CALC_TYPES
+from .layout import parse_matrix_info
+
+# internal require-names used in the C++ error strings (bse.hpp)
+_REQUIRE_NAME = {"X0_loc": "X0_Loc"}  # others equal their set name
+
+# calc_type -> list of required set names (from bse.hpp require() calls)
+_REQUIRED = {
+    "chi0": ["X0_q", "X0_loc", "chi0_loc"],
+    "bse": ["X0_q", "X0_loc", "X_loc", "chi_loc"],
+    "rpa": ["gamma0", "chi0_q"],
+    "rrpa": ["chi0_loc", "chi_loc", "chi0_q"],
+    "scl": ["X0_q", "X0_loc", "Phi", "Phi_sum"],
+}
+
+
+class NumpySolver(SolverBase):
+    def __init__(self, beta, info_A, info_B, info_C):
+        super().__init__(beta, info_A, info_B, info_C)
+        self.nb, self.nw, self.n_in = parse_matrix_info(info_A, info_B, info_C)
+        self._in = {}
+        self._out = {}
+
+    def set(self, bm, name):
+        if name not in SET_LAYOUT:
+            raise RuntimeError(f"Invalid type '{name}'")
+        self._in[name] = {k: np.asarray(v, dtype=complex) for k, v in bm.items()}
+
+    def _require(self, calc_type):
+        for name in _REQUIRED[calc_type]:
+            if name not in self._in:
+                internal = _REQUIRE_NAME.get(name, name)
+                raise RuntimeError(f"'{internal}' must be set before calling calc.")
+
+    def calc(self, calc_type):
+        ct = str(calc_type).lower()
+        if ct not in CALC_TYPES:
+            raise RuntimeError(f"Invalid type '{calc_type}'")
+        self._require(ct)
+        fn = {
+            "chi0": kernels.calc_chi0,
+            # bse/rpa/rrpa/scl added in later tasks
+        }[ct]
+        result = fn(self._in, self.beta, self.nb, self.nw, self.n_in)
+        self._out.update(result)
+        # I_q and I_q_scl are one slot in C++ (both GetIq()): whichever
+        # irreducible vertex was computed most recently answers to both names.
+        if "I_q" in result:
+            self._out["I_q_scl"] = result["I_q"]
+        if "I_q_scl" in result:
+            self._out["I_q"] = result["I_q_scl"]
+
+    def get(self, name):
+        return self._out.get(name, {})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_facade.py tests/python/non-mpi/solver/test_numpy_chi0.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/kernels.py python/package/chiq/solver/numpy.py tests/python/non-mpi/solver/test_numpy_facade.py tests/python/non-mpi/solver/test_numpy_chi0.py
+git commit -m "feat(solver): NumpySolver facade + chi0 kernel"
+```
+
+---
+
+### Task 9: kernels — bse
+
+**Files:**
+- Modify: `python/package/chiq/solver/kernels.py`
+- Modify: `python/package/chiq/solver/numpy.py` (register `bse`)
+- Test: `tests/python/non-mpi/solver/test_numpy_bse.py`
+
+**Interfaces:**
+- Consumes: `layout`, `calc_chi0`.
+- Produces: `kernels.calc_bse(state, beta, nb, nw, n_in) -> {"chi_q":..., "I_q":...}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_numpy_bse.py
+import numpy as np
+from chiq.solver import get_solver
+from chiq.solver.kernels import calc_bse
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def test_iq_and_iq_scl_share_one_slot():
+    # After a bse calc, get("I_q_scl") returns the same value as get("I_q").
+    nb, nw, n_in = 1, 2, 1
+    s = get_solver("numpy", 5.0, *_info(nb, nw, n_in))
+    X0 = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[2.0]], complex)}
+    s.set(X0, "X0_q")
+    s.set(X0, "X0_loc")
+    s.set({(0, 0): np.eye(2, dtype=complex)}, "X_loc")
+    s.set({(0, 0): np.array([[3.0]], complex)}, "chi_loc")
+    s.calc("bse")
+    assert s.get("I_q_scl") == s.get("I_q")
+
+def test_bse_reduces_to_chi_loc_when_X0q_equals_X0loc():
+    # If X0_q == X0_loc then P_q = 0, Z_q = 0, so chi_q == chi_loc.
+    nb, nw, n_in, beta = 1, 2, 1, 5.0
+    X0 = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[2.0]], complex)}
+    X_loc = {(0, 0): np.array([[1.0, 0.0], [0.0, 1.0]], complex)}  # A-type 2x2
+    chi_loc = {(0, 0): np.array([[3.0]], complex)}
+    state = {"X0_q": X0, "X0_loc": X0, "X_loc": X_loc, "chi_loc": chi_loc}
+    out = calc_bse(state, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q"][(0, 0)], [[3.0]])
+    # I_q = chi_loc^-1 - chi_q^-1 = 0 here
+    assert np.allclose(out["I_q"][(0, 0)], [[0.0]])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_bse.py -v`
+Expected: FAIL (`calc_bse` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/kernels.py
+
+def calc_bse(state, beta, nb, nw, n_in):
+    info_A = [n_in * nw] * nb
+    info_B = [n_in] * (nb * nw)  # noqa: F841
+    info_C = [n_in] * nb  # noqa: F841
+    X0_loc = state["X0_loc"]
+    X0_q = state["X0_q"]
+    X_loc = state["X_loc"]
+    chi_loc = state["chi_loc"]
+
+    Pq = L.sub(L.block_inverse(X0_loc, [n_in] * (nb * nw)),
+               L.block_inverse(X0_q, [n_in] * (nb * nw)))            # B-type
+    Xloc_Pq = L.prod_ab(X_loc, Pq, nb, nw, n_in)                     # A-type
+    ident_A = L.identity(info_A)
+    inner = L.sub(L.block_inverse(L.sub(ident_A, Xloc_Pq), info_A), ident_A)  # A-type
+    Zq = L.matmul(inner, X_loc, info_A)                             # A-type
+    chi_q = L.add(chi_loc, L.scale(1.0 / beta, L.sumfreq_a(Zq, nb, nw, n_in)))  # C-type
+    Iq = L.sub(L.block_inverse(chi_loc, [n_in] * nb),
+               L.block_inverse(chi_q, [n_in] * nb))                  # C-type
+    return {"chi_q": chi_q, "I_q": Iq}
+```
+
+Register it in `numpy.py`'s dispatch dict:
+
+```python
+# in NumpySolver.calc, extend the dispatch:
+fn = {
+    "chi0": kernels.calc_chi0,
+    "bse": kernels.calc_bse,
+}[ct]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_bse.py -v`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/kernels.py python/package/chiq/solver/numpy.py tests/python/non-mpi/solver/test_numpy_bse.py
+git commit -m "feat(solver): bse kernel"
+```
+
+---
+
+### Task 10: kernels — rpa and rrpa
+
+**Files:**
+- Modify: `python/package/chiq/solver/kernels.py`
+- Modify: `python/package/chiq/solver/numpy.py`
+- Test: `tests/python/non-mpi/solver/test_numpy_rpa.py`
+
+**Interfaces:**
+- Consumes: `layout`.
+- Produces: `kernels.calc_rpa(state, beta, nb, nw, n_in) -> {"chi_q_rpa":...}`; `kernels.calc_rrpa(...) -> {"chi_q_rrpa":...}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_numpy_rpa.py
+import numpy as np
+from chiq.solver.kernels import calc_rpa, calc_rrpa
+
+def test_rpa_zero_gamma_gives_chi0():
+    nb, nw, n_in, beta = 1, 1, 1, 1.0
+    chi0_q = {(0, 0): np.array([[2.0]], complex)}
+    gamma0 = {(0, 0): np.array([[0.0]], complex)}
+    out = calc_rpa({"chi0_q": chi0_q, "gamma0": gamma0}, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q_rpa"][(0, 0)], [[2.0]])
+
+def test_rrpa_when_chi0loc_equals_chiloc_gives_chi0q():
+    # U_eff = chi0_loc^-1 - chi_loc^-1 = 0 -> chi_q_rrpa = chi0_q
+    nb, nw, n_in, beta = 1, 1, 1, 1.0
+    same = {(0, 0): np.array([[3.0]], complex)}
+    chi0_q = {(0, 0): np.array([[2.0]], complex)}
+    out = calc_rrpa({"chi0_loc": same, "chi_loc": same, "chi0_q": chi0_q}, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q_rrpa"][(0, 0)], [[2.0]])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_rpa.py -v`
+Expected: FAIL (`calc_rpa`/`calc_rrpa` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/kernels.py
+
+def calc_rpa(state, beta, nb, nw, n_in):
+    info_C = [n_in] * nb
+    chi0_q = state["chi0_q"]
+    gamma0 = state["gamma0"]
+    m = L.sub(L.identity(info_C), L.matmul(chi0_q, gamma0, info_C))
+    chi_q_rpa = L.matmul(L.block_inverse(m, info_C), chi0_q, info_C)
+    return {"chi_q_rpa": chi_q_rpa}
+
+
+def calc_rrpa(state, beta, nb, nw, n_in):
+    info_C = [n_in] * nb
+    chi0_loc = state["chi0_loc"]
+    chi_loc = state["chi_loc"]
+    chi0_q = state["chi0_q"]
+    Ueff = L.sub(L.block_inverse(chi0_loc, info_C), L.block_inverse(chi_loc, info_C))
+    m = L.sub(L.identity(info_C), L.matmul(chi0_q, Ueff, info_C))
+    chi_q_rrpa = L.matmul(L.block_inverse(m, info_C), chi0_q, info_C)
+    return {"chi_q_rrpa": chi_q_rrpa}
+```
+
+Register both in `numpy.py`:
+
+```python
+fn = {
+    "chi0": kernels.calc_chi0,
+    "bse": kernels.calc_bse,
+    "rpa": kernels.calc_rpa,
+    "rrpa": kernels.calc_rrpa,
+}[ct]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_rpa.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/kernels.py python/package/chiq/solver/numpy.py tests/python/non-mpi/solver/test_numpy_rpa.py
+git commit -m "feat(solver): rpa and rrpa kernels"
+```
+
+---
+
+### Task 11: kernels — scl
+
+**Files:**
+- Modify: `python/package/chiq/solver/kernels.py`
+- Modify: `python/package/chiq/solver/numpy.py`
+- Test: `tests/python/non-mpi/solver/test_numpy_scl.py`
+
+**Interfaces:**
+- Consumes: `layout`.
+- Produces: `kernels.calc_scl(state, beta, nb, nw, n_in) -> {"chi_q_scl":..., "I_q_scl":...}`. Note: `Phi` (B-type) and `Phi_sum` (C-type) are provided by the driver via `set`; the kernel does not compute the matrix sqrt.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_numpy_scl.py
+import numpy as np
+from chiq.solver.kernels import calc_scl
+
+def test_scl_when_X0q_equals_X0loc_gives_phisum_squared():
+    # Lambda_q = X0_loc^-1 - X0_q^-1 = 0 -> lambda_q = 0
+    # chi_q_scl = Phi_sum * I^-1 * Phi_sum = Phi_sum @ Phi_sum
+    nb, nw, n_in, beta = 1, 2, 1, 1.0
+    X0 = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[2.0]], complex)}
+    Phi = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[1.0]], complex)}  # B-type
+    Phi_sum = {(0, 0): np.array([[3.0]], complex)}  # C-type
+    out = calc_scl({"X0_q": X0, "X0_loc": X0, "Phi": Phi, "Phi_sum": Phi_sum}, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q_scl"][(0, 0)], [[9.0]])   # 3*3
+    assert np.allclose(out["I_q_scl"][(0, 0)], [[0.0]])     # Phi_sum^-1 * 0 * Phi_sum^-1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_scl.py -v`
+Expected: FAIL (`calc_scl` undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to python/package/chiq/solver/kernels.py
+
+def calc_scl(state, beta, nb, nw, n_in):
+    info_B = [n_in] * (nb * nw)
+    info_C = [n_in] * nb
+    X0_loc = state["X0_loc"]
+    X0_q = state["X0_q"]
+    Phi = state["Phi"]
+    Phi_sum = state["Phi_sum"]
+
+    Lambdaq = L.sub(L.block_inverse(X0_loc, info_B), L.block_inverse(X0_q, info_B))  # B
+    lambda_q = L.sumfreq_b(L.matmul(L.matmul(Phi, Lambdaq, info_B), Phi, info_B),
+                           nb, nw, n_in)                                            # C
+    m = L.sub(L.identity(info_C), lambda_q)
+    chi_q_scl = L.matmul(L.matmul(Phi_sum, L.block_inverse(m, info_C), info_C),
+                         Phi_sum, info_C)
+    phisum_inv = L.block_inverse(Phi_sum, info_C)
+    Iq = L.matmul(L.matmul(phisum_inv, lambda_q, info_C), phisum_inv, info_C)
+    return {"chi_q_scl": chi_q_scl, "I_q_scl": Iq}
+```
+
+Register in `numpy.py`:
+
+```python
+fn = {
+    "chi0": kernels.calc_chi0,
+    "bse": kernels.calc_bse,
+    "rpa": kernels.calc_rpa,
+    "rrpa": kernels.calc_rrpa,
+    "scl": kernels.calc_scl,
+}[ct]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_numpy_scl.py -v`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/kernels.py python/package/chiq/solver/numpy.py tests/python/non-mpi/solver/test_numpy_scl.py
+git commit -m "feat(solver): scl kernel"
+```
+
+---
+
+### Task 12: backend-agreement tests over the integration fixtures
+
+**Files:**
+- Create: `tests/python/non-mpi/solver/test_backend_agreement.py`
+- Test: itself.
+
+**Interfaces:**
+- Consumes: `get_solver`, existing fixture HDF5 inputs and the `chi_*` worker classes in `chiq_main` (imported for building the per-(ω,q) block-matrix dicts), OR — simpler and preferred — construct random well-conditioned inputs of the shapes each calc needs and compare `cpp` vs `numpy` directly. Use the direct approach to avoid coupling to the driver's HDF5 layout.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_backend_agreement.py
+import numpy as np
+import pytest
+from chiq.solver import get_solver
+
+RNG = np.random.default_rng(0)
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def _rand_c(shape):
+    return (RNG.standard_normal(shape) + 1j * RNG.standard_normal(shape))
+
+def _well_conditioned(n):
+    # diagonally dominant -> invertible, bounded condition number
+    m = _rand_c((n, n))
+    return m + n * np.eye(n)
+
+def _assert_agree(a, b):
+    for k in set(a) | set(b):
+        if k in a and k in b:
+            va, vb = a[k], b[k]
+        elif k in a:
+            va, vb = a[k], np.zeros_like(a[k])
+        else:
+            va, vb = np.zeros_like(b[k]), b[k]
+        # NaN / signed-inf position masks, then elementwise mixed tolerance
+        assert np.array_equal(np.isnan(va), np.isnan(vb))
+        assert np.array_equal(np.isposinf(va), np.isposinf(vb))
+        assert np.array_equal(np.isneginf(va), np.isneginf(vb))
+        np.testing.assert_allclose(va, vb, rtol=1e-8, atol=1e-10, equal_nan=True)
+
+def _c_blocks(nb, n_in):
+    return {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)}
+
+def _c_blocks_wc(nb, n_in):
+    # C-type with well-conditioned diagonal blocks (invertible)
+    d = {(i, i): _well_conditioned(n_in) for i in range(nb)}
+    return d
+
+def _b_blocks_diag(nb, nw, n_in):
+    return {(iw * nb + b, iw * nb + b2): _rand_c((n_in, n_in))
+            for iw in range(nw) for b in range(nb) for b2 in range(nb)}
+
+def _b_blocks_diag_wc(nb, nw, n_in):
+    # B-type well-conditioned in each same-iw super-block (diagonal blocks dominant)
+    out = {}
+    for iw in range(nw):
+        for b in range(nb):
+            for b2 in range(nb):
+                m = _rand_c((n_in, n_in))
+                if b == b2:
+                    m = m + (nb * n_in) * np.eye(n_in)
+                out[(iw * nb + b, iw * nb + b2)] = m
+    return out
+
+def _a_blocks(nb, nw, n_in):
+    return {(i, j): _rand_c((n_in * nw, n_in * nw)) for i in range(nb) for j in range(nb)}
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2), (2, 3, 2)])
+def test_chi0_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = {
+        "chi0_loc": {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)},
+        "X0_loc": {(iw * nb + b, iw * nb + b2): _rand_c((n_in, n_in))
+                   for iw in range(nw) for b in range(nb) for b2 in range(nb)},
+    }
+    inputs["X0_q"] = {k: _rand_c((n_in, n_in)) for k in inputs["X0_loc"]}
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("chi0")
+        outs[backend] = s.get("chi0_q")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_rpa_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    chi0_q = {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)}
+    gamma0 = {(i, i): 0.01 * _rand_c((n_in, n_in)) for i in range(nb)}
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        s.set(chi0_q, "chi0_q")
+        s.set(gamma0, "gamma0")
+        s.calc("rpa")
+        outs[backend] = s.get("chi_q_rpa")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_rrpa_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = {
+        "chi0_loc": _c_blocks_wc(nb, n_in),
+        "chi_loc": _c_blocks_wc(nb, n_in),
+        "chi0_q": _c_blocks(nb, n_in),
+    }
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("rrpa")
+        outs[backend] = s.get("chi_q_rrpa")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_bse_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    X0_loc = _b_blocks_diag_wc(nb, nw, n_in)
+    inputs = {
+        "X0_loc": X0_loc,
+        "X0_q": _b_blocks_diag_wc(nb, nw, n_in),
+        "X_loc": _a_blocks(nb, nw, n_in),
+        "chi_loc": _c_blocks_wc(nb, n_in),
+    }
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("bse")
+        outs[backend] = s.get("chi_q")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_scl_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = {
+        "X0_loc": _b_blocks_diag_wc(nb, nw, n_in),
+        "X0_q": _b_blocks_diag_wc(nb, nw, n_in),
+        "Phi": _b_blocks_diag(nb, nw, n_in),
+        "Phi_sum": _c_blocks_wc(nb, n_in),
+    }
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("scl")
+        outs[backend] = s.get("chi_q_scl")
+    _assert_agree(outs["cpp"], outs["numpy"])
+```
+
+- [ ] **Step 2: Run test to verify it fails or errors**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_backend_agreement.py -v` (needs built `bse_solver`).
+Expected: initially FAIL if any kernel disagrees with C++ — investigate and fix the layout/kernel until agreement holds. (Common causes: a transpose in `sumfreq_a` reshape, or a wrong operand order in a `matmul`.)
+
+- [ ] **Step 3: Fix any disagreements**
+
+If a test fails, compare a single failing block between backends, localize to one layout
+op with a targeted unit test, fix `layout.py`/`kernels.py`, and re-run. Do not loosen the
+tolerance; the metric is fixed by the Global Constraints.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_backend_agreement.py -v`
+Expected: PASS (all parametrizations).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/python/non-mpi/solver/test_backend_agreement.py
+git commit -m "test(solver): cpp vs numpy backend agreement across calc types"
+```
+
+---
+
+### Task 13: CupySolver skeleton + factory wiring
+
+**Files:**
+- Create: `python/package/chiq/solver/cupy.py`
+- Test: `tests/python/non-mpi/solver/test_cupy_skeleton.py`
+
+**Interfaces:**
+- Consumes: `SolverBase`.
+- Produces: `CupySolver(SolverBase)` whose constructor raises a clear error (cupy not enabled / not installed). No numerical execution this phase.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/non-mpi/solver/test_cupy_skeleton.py
+import pytest
+from chiq.solver import get_solver
+
+def test_cupy_backend_not_enabled():
+    with pytest.raises((NotImplementedError, ImportError, RuntimeError)) as exc:
+        get_solver("cupy", 10.0, [2], [1, 1], [1])
+    assert "cupy" in str(exc.value).lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_cupy_skeleton.py -v`
+Expected: FAIL (`chiq.solver.cupy` undefined -> factory ImportError with wrong message, or ModuleNotFoundError).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# python/package/chiq/solver/cupy.py
+"""CuPy/GPU backend skeleton. Enabled in a later GPU phase."""
+
+from .base import SolverBase
+
+
+class CupySolver(SolverBase):
+    def __init__(self, beta, info_A, info_B, info_C):
+        super().__init__(beta, info_A, info_B, info_C)
+        raise NotImplementedError(
+            "cupy backend not yet enabled (planned for the GPU phase)."
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/non-mpi/solver/test_cupy_skeleton.py -v`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/package/chiq/solver/cupy.py tests/python/non-mpi/solver/test_cupy_skeleton.py
+git commit -m "feat(solver): CupySolver skeleton raising a clear not-enabled error"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the whole non-MPI suite (with the built `bse_solver` importable):
+  `python -m pytest tests/python/non-mpi -v` — all green, including the pre-existing fixtures (proving the Task 7 refactor is behavior-preserving) and the new `solver/` tests.
+- [ ] Confirm default behavior unchanged: run an example end-to-end (`examples/square_bse/run.sh` with `NPROCS=1`) and diff outputs against a pre-change run — identical.
+- [ ] Confirm the `numpy` backend runs end-to-end: set `[chiq_main] backend = "numpy"` in a fixture `bse.toml` and run `chiq_main.py` on it; results match the `cpp` run within tolerance.
+
+## Out of scope (separate plan)
+
+pip packaging (§5 of the spec): `pyproject.toml` + scikit-build-core, renaming the pybind
+module/target to `_bse_solver`, `console_scripts` entry points, `bse`/`bse_solver`
+compatibility shims, wheel/sdist install tests, Python-floor bump to 3.10, and the
+`toml`/`scipy` dependency declarations. That plan swaps `cpp.py`'s `import bse_solver`
+for `from chiq import _bse_solver` behind the top-level shim.

--- a/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
+++ b/docs/superpowers/plans/2026-07-12-numpy-solver-backend.md
@@ -980,7 +980,7 @@ class NumpySolver(SolverBase):
     def set(self, bm, name):
         if name not in SET_LAYOUT:
             raise RuntimeError(f"Invalid type '{name}'")
-        self._in[name] = {k: np.asarray(v, dtype=complex) for k, v in bm.items()}
+        self._in[name] = {k: np.array(v, dtype=np.complex128, copy=True) for k, v in bm.items()}
 
     def _require(self, calc_type):
         for name in _REQUIRED[calc_type]:
@@ -1011,7 +1011,8 @@ class NumpySolver(SolverBase):
         # not-yet-computed -> {}
         if name not in GET_NAMES:
             raise RuntimeError(f"Invalid type '{name}'")
-        return self._out.get(name, {})
+        # return owned copies so callers can't mutate cached results (match C++)
+        return {k: v.copy() for k, v in self._out.get(name, {}).items()}
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**

--- a/docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md
+++ b/docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md
@@ -1,0 +1,460 @@
+# Design: NumPy solver backend + backend-switch + pip packaging (Phase 0)
+
+**Date:** 2026-07-12
+**Status:** Draft for review (round 3 — incorporates Codex design review rounds 1–3)
+**Repo:** ChiQ (Bethe-Salpeter / DMFT momentum-dependent susceptibility solver)
+
+## 1. Context and goal
+
+ChiQ's heavy numerics live in a C++ BSE solver (`src/bse.hpp`, `src/block_matrix.hpp`)
+exposed to Python via pybind11 (`src/bse_solver_pybind.cpp`, module `bse_solver`).
+Python scripts (`python/scripts/chiq_main.py`, `chiq_post.py`) drive it: for each
+(bosonic frequency ω, momentum q) they build a block matrix as a Python
+`dict{(block1, block2): ndarray}`, call `solver.set(...)`, `solver.calc(type)`,
+then `solver.get(...)`.
+
+The long-term goal (agreed with the user) is **GPU acceleration** and **IR-basis
+(sparse-ir) adoption**. The chosen strategy is *not* to CUDA-ify the C++, but to
+introduce a **NumPy/CuPy-switchable solver backend in Python**, because the data
+already lives as dict-of-ndarrays and the operations are dense block linear algebra.
+
+**This spec (Phase 0)** is the foundation everything else builds on. Three deliverables:
+
+1. A **backend abstraction** (`backend = "cpp" | "numpy" | "cupy"`) with the C++
+   and NumPy backends implemented (CuPy is skeleton only, activated in a later phase).
+2. **Numerical-agreement tests** proving the NumPy backend matches C++.
+3. **pip packaging** via scikit-build-core so `pip install .` builds the C++
+   extension and installs the CLI, replacing the CMake-install + `chiqvars.sh`
+   PYTHONPATH workflow.
+
+Out of scope: sparse-ir integration, actual GPU/CuPy execution and tuning, and any
+change to the BSE numerical algorithm. Those are later phases that depend on this one.
+
+## 2. Non-goals / constraints
+
+- **Zero behavior change by default.** Default backend stays `cpp`; existing runs,
+  outputs, and the `import bse` compatibility path are preserved.
+- **C++ is retained**, not retired. It is a co-equal, permanent backend and the
+  numerical oracle for the NumPy/CuPy backends.
+- **Compatibility target = mathematical equivalence within tolerance**, not bitwise
+  reproduction of C++ rounding. (This distinction is deliberate so future numerical
+  improvements are not blocked by the oracle — see §4.)
+- **Python floor rises to 3.10** (3.8/3.9 EOL). CI matrix becomes 3.10 … 3.13; the
+  dependency/version matrix is pinned in §5.4.
+- No unrelated refactors; targeted fixes only where they serve this work.
+
+## 3. Architecture: backend abstraction
+
+### 3.1 Component decomposition
+
+Three separated concerns (Codex alternative "separate layout / state / kernels"):
+
+- **`chiq.solver.layout`** — the *only* owner of block-dict ↔ dense mapping and the
+  A/B/C conventions (§3.4). Pure functions, no solver state. `chiq_main._reformat_data`
+  and the `_convert_block_matrix` reshapes move here; `chiq_main.py` keeps no
+  numerical/indexing logic.
+- **`chiq.solver` kernels** — the five calculations (§3.5) written against a narrow
+  array/linalg protocol `xp` (an injected module: `numpy` or `cupy`) plus a tiny
+  `linalg` adapter (`solve`, `inv`). One shared kernel implementation; the backend is
+  chosen by which `xp`/adapter is injected — **not** by subclassing (Codex should-fix).
+- **`chiq.solver` facade** — the stateful `set`/`calc`/`get` triad (§3.2, §3.3),
+  a thin compatibility layer over the kernels.
+
+### 3.2 Public interface (facade)
+
+```
+class SolverBase:
+    def __init__(self, beta, matrix_info_A, matrix_info_B, matrix_info_C): ...
+    def set(self, block_matrix_dict, name: str) -> None
+    def calc(self, calc_type: str) -> None      # "chi0"|"bse"|"rpa"|"rrpa"|"scl"
+    def get(self, name: str) -> dict             # {(b1,b2): ndarray}
+```
+
+Backends:
+
+- `CppSolver` — thin wrapper over `bse_solver.BSESolver`. Behavior identical to today
+  (delegates set/calc/get verbatim; complex128; same error strings).
+- `NumpySolver` — kernels with `xp = numpy`, `linalg = numpy.linalg`.
+- `CupySolver` — same kernels with `xp = cupy`; host→device on `set`, device→host on
+  `get`. **Skeleton only** this phase: constructed via the factory but raises a clear
+  `NotImplementedError("cupy backend not yet enabled")` / a clear error if cupy is
+  absent. No CI execution (no GPU).
+
+`get_solver(backend, beta, info_A, info_B, info_C) -> SolverBase` is the factory.
+`chiq_main.py` obtains its solver only through it.
+
+### 3.3 State machine and per-calc contract (normative)
+
+**Set names → matrix-info type** (from `src/bse_solver_pybind.cpp:46-100`):
+
+| name       | layout | notes                         |
+|------------|--------|-------------------------------|
+| `X_loc`    | A      | local full two-particle       |
+| `X0_loc`   | B      | local bare                    |
+| `X0_q`     | B      | q-dependent bare              |
+| `Phi`      | B      | SCL vertex                    |
+| `chi_loc`  | C      | local physical susceptibility |
+| `chi0_loc` | C      | local bare physical           |
+| `chi0_q`   | C      | q bare physical (RPA/RRPA in) |
+| `gamma0`   | C      | bare vertex                   |
+| `Phi_sum`  | C      | SCL summed vertex (√chi_loc)  |
+
+**calc_type → required set names / produced get names** (from `bse.hpp` `require()`
+calls and `chiq_main.py` worker classes `chi_chi0/chi_bse/chi_rpa/chi_rrpa/chi_scl`):
+
+| calc   | requires (set)                    | produces (get)                 |
+|--------|-----------------------------------|--------------------------------|
+| `chi0` | X0_q, X0_loc, chi0_loc            | chi0_q                         |
+| `bse`  | X0_q, X0_loc, X_loc, chi_loc      | chi0_q?†, chi_q, I_q           |
+| `rpa`  | chi0_q, gamma0                    | chi_q_rpa                      |
+| `rrpa` | chi0_q, chi0_loc, chi_loc         | chi_q_rrpa                     |
+| `scl`  | X0_q, X0_loc, Phi, Phi_sum        | chi_q_scl, I_q_scl             |
+
+† `chi0_q` for `bse` is produced by a preceding `chi0` calc in the driver, not by
+`CalcChiq_BSE`; the driver's `output_q` lists reflect what is written to HDF5. The
+solver contract is: `get(name)` returns the last computed result of that name and
+raises `KeyError`-style errors if that calc has not run.
+
+**Lifecycle / error semantics** (match observed C++ behavior):
+- `set` is idempotent-overwrite: setting the same name replaces prior data.
+- `calc` requires all inputs in its row to be set; a missing input raises
+  `RuntimeError("'<name>' must be set before calling calc.")` (mirrors
+  `bse.hpp` `require`).
+- Repeated `calc` recomputes from currently-set inputs and overwrites outputs.
+- **No output caching / no auto-invalidation** (matches C++ `BSESolver`, which holds
+  inputs by pointer and recomputes on each `calc`): `get` returns the result of the
+  most recent `calc`; changing an input via `set` does **not** retroactively update or
+  invalidate a prior `get` result. The driver's contract is `set → calc → get` in
+  order per (ω,q), so staleness cannot arise in practice; this behavior is documented
+  as compatibility-required rather than "fixed".
+- Unknown set/get/calc names raise `RuntimeError("Invalid type '<name>'")` (mirrors
+  the pybind `else` branches). `CppSolver` inherits these verbatim; `NumpySolver`
+  raises the same messages so tests are backend-agnostic.
+
+**Ownership/aliasing:** `set` copies inputs (defensive; matches C++ which copies into
+its own block_matrix). `get` returns freshly-assembled dicts of owned arrays (not
+internal views). A round-trip mutation test asserts this for both backends.
+
+**dtype:** inputs are normalized to `complex128` on `set` (the C++ binding does the
+same via `dict_to_blockmatrix<complex<double>>`); `get` returns `complex128`.
+
+### 3.4 Canonical block layout (normative)
+
+**Every block matrix is a `dict{(vi, vj): ndarray}`** keyed by an *ordered pair of
+integer vertices* `(vi, vj)`; a missing key means a **structural zero** (a coupling
+that is mathematically forbidden, not merely numerically small — see §8 risk
+disposition). Dimensions come solely from the three matrix-info vectors; no global
+state is consulted. Let `nb` = number of C-vertices, `nw` = number of frequencies,
+`n_in` = inner dimension.
+
+**Uniform-dimension invariant (committed).** In ChiQ, `n_in` and `nw` are the same
+for every block: the driver builds `matinfo_A = [n_iw*n_inner]*n_block`,
+`matinfo_B = [n_inner]*(n_block*n_iw)`, `matinfo_C = [n_inner]*n_block`
+(`chiq_main.py:524-526`), and `_save_X0_info` asserts identical inner structure
+across all blocks (`sumk_dft_chi.py:579-580`). The layout module **requires** uniform
+`n_in`/`nw` and raises on any non-uniform matrix-info. (The per-component solve in
+§3.5 does not itself rely on uniformity, but the public contract does; heterogeneous
+blocks are explicitly unsupported in Phase 0.)
+
+| layout | vertex set (key domain)        | array shape per key      | info vector       |
+|--------|--------------------------------|--------------------------|-------------------|
+| C      | `v ∈ [0, nb)`                  | `n_in × n_in`            | `info_C[v]=n_in`  |
+| B      | `v = iw*nb + b`, `iw∈[0,nw)`   | `n_in × n_in`            | `info_B[v]=n_in`  |
+| A      | `v ∈ [0, nb)`                  | `(n_in*nw) × (n_in*nw)`  | `info_A[v]=n_in*nw` |
+
+- B is structurally block-diagonal in `iw`: only keys `(iw*nb+b_i, iw*nb+b_j)`
+  (same `iw`) may be present.
+- A flattens its inner index as `in*nw + iw`.
+- All blocks are **square**; the layout module asserts this and A/B/C mutual
+  consistency (`nb, nw, n_in`) on construction, raising on mismatch.
+
+Reductions/conversions are functions `dict → dict` with the exact key/shape contract
+(reproduced from `bse.hpp`, each with a unit test):
+- `Sumfreq_A` (A→C): output key `(b_i,b_j)`, shape `n_in×n_in`;
+  `out[(i,j)][a,c] = Σ_{iw1,iw2} A[(i,j)][a*nw+iw1, c*nw+iw2]`.
+- `Sumfreq_B` (B→C): output key `(b_i,b_j)`;
+  `out[(i,j)] = Σ_iw B[(iw*nb+i, iw*nb+j)]` over keys present.
+- `Convert_A2B` (A→B) / `Convert_B2A` (B→A): index remap per `bse.hpp:519-613`;
+  keys and shapes follow the B/A domains above.
+
+### 3.5 Kernel formulas (ordered, matching C++)
+
+Identity matrices carry the layout of the operand. `β` scaling is applied on the
+C-type sum as shown. `solve(A, B) ≡ A⁻¹ B` (left solve).
+
+- **chi0** (`bse.hpp:223`): `chi0_q = chi0_loc + (1/β)·Sumfreq_B(X0_q − X0_loc)`.
+- **bse** (`bse.hpp:244`):
+  `Pq = inv(X0_loc) − inv(X0_q)` (B-type, explicit inverse — Pq is consumed as data);
+  `XlocPq = ProdAB(X_loc, Pq)` (A-type);
+  `Zq = solve(I − XlocPq, X_loc) − X_loc` (A-type; `([1−XlocPq]⁻¹ − 1)·X_loc`);
+  `chi_q = chi_loc + (1/β)·Sumfreq_A(Zq)`;
+  `I_q = inv(chi_loc) − inv(chi_q)` (explicit inverses — outputs).
+- **rpa** (`bse.hpp:281`): `chi_q_rpa = solve(I − chi0_q·gamma0, chi0_q)` (C-type).
+- **rrpa** (`bse.hpp:301`): `Ueff = inv(chi0_loc) − inv(chi_loc)`;
+  `chi_q_rrpa = solve(I − chi0_q·Ueff, chi0_q)`.
+- **scl** (`bse.hpp:326`): `Lambdaq = inv(X0_loc) − inv(X0_q)` (B);
+  `lambda_q = Sumfreq_B(Phi·Lambdaq·Phi)` (C);
+  `chi_q_scl = Phi_sum · solve(I − lambda_q, Phi_sum)`;
+  `I_q_scl = inv(Phi_sum)·lambda_q·inv(Phi_sum)`.
+
+**Block-structure-preserving inverse/solve + fill-in rule (resolves dense-vs-groupwise
+and fill-in concerns).** `inv`/`solve` are performed **per connected component** of
+the block-sparsity graph, reproducing `block_matrix.hpp:541` (`gather_blocks`):
+assemble each component into a dense super-block, invert/solve it, scatter back.
+Component derivation and fill-in match C++ exactly:
+- **Components** are connected components under the undirected edge
+  `connected(i,j) = exists(i,j) or exists(j,i)` (`block_matrix.hpp:547`). For binary
+  `solve(A, B)`, components are taken from `A` (the matrix being inverted); `B` must
+  share `A`'s block structure (C++ enforces this in `operator*` /
+  `has_same_block_structure`).
+- **Fill-in:** the inverted super-block is dense, and C++ **emits every vertex pair
+  `(vi, vj)` within the component** (`block_matrix.hpp:590-602` assigns all `bl,bl2`),
+  including pairs absent from the input. The NumPy `inv`/`solve` reproduce this: output
+  keys = all intra-component pairs; **numerical zeros are retained** (not pruned).
+  Cross-component pairs remain absent (structural zero).
+- Products (`*`) emit keys **symbolically**, not by numerical value: C++ `operator*`
+  (`block_matrix.hpp:639-650`) sets a key `(i,j)` iff **∃ k with both `(i,k)` and
+  `(k,j)` present** — the decision is `exists(i,k) && exists(k,j)`, independent of the
+  numerical result. The NumPy `*` reproduces this exact key-path rule, so the output
+  sparsity graph is backend-identical regardless of floating-point cancellation.
+  Differences (`-`) are entrywise over the union of present keys. Downstream
+  `Sumfreq_*`/`Convert_*`/`get` consume whatever keys are present. No operation ever
+  decides key presence from a numerical zero-test.
+
+This is (a) *mathematically identical* to C++ because the full operator is
+block-diagonal across components, and (b) preserves the C++ complexity `Σ_g dim(g)³`,
+mapping directly onto GPU batched solves later.
+
+**Singular / near-singular policy.** The compatibility contract (equivalence within
+tolerance) covers **non-singular inputs only**; all physical test fixtures are
+well-conditioned, so this path is not exercised for backend-agreement. For a singular
+component, behavior is *defined but not claimed bit-compatible with C++*: NumPy catches
+`LinAlgError` and emits an **all-NaN component** (documented, backend-independent
+semantics), with `xp.errstate` suppressing spurious warnings. This flows into the
+existing NaN guard in `chiq_main.output2hdf5` exactly as a C++ inf/nan result would.
+(Whether that guard should hard-error is a separate, out-of-scope fix.)
+
+### 3.6 Files touched / added
+
+- New: `python/package/chiq/solver/__init__.py` (factory), `base.py`, `layout.py`,
+  `kernels.py`, `cpp.py`, `numpy.py`, `cupy.py`.
+- Edit: `python/scripts/chiq_main.py` (use factory; drop direct `bse_solver` import
+  and inline solver construction; drop `_reformat_data`/reshapes now in `layout`),
+  `python/package/chiq/bse_toml.py` (parse+validate `backend`).
+- Edit (packaging): `src/bse_solver_pybind.cpp` — rename the module declaration
+  `PYBIND11_MODULE(bse_solver, m)` → `PYBIND11_MODULE(_bse_solver, m)` so the compiled
+  binary exports `PyInit__bse_solver` and is importable as `chiq._bse_solver`. (Only
+  the module name changes; the `BSESolver` class and its bindings are identical.)
+  `src/CMakeLists.txt` / `python/CMakeLists.txt` install the extension into the `chiq`
+  package directory. Both the pip (scikit-build-core) and direct-CMake paths install to
+  the same package-relative location, so `import chiq._bse_solver` works identically
+  (§5.3, verified by §4.5 tests). The top-level name `bse_solver` survives as a
+  pure-Python shim (§5.2).
+
+## 4. Testing / numerical verification
+
+Layers:
+
+1. **Backend-agreement (primary).** Parametrize the existing integration fixtures
+   (`tests/python/non-mpi/bsetool_{BSE,RPA,SCL,RRPA}`) over `backend ∈ {cpp, numpy}`;
+   assert `numpy` == `cpp` on identical input. Two fixed, non-discretionary metrics,
+   aggregated as the max over all present blocks (a NaN/Inf in one backend but not the
+   other, at the same position, is an immediate failure):
+   - **mixed-tolerance absolute error** (standard `numpy.allclose` convention):
+     `max|cpp - numpy| <= atol + rtol*max|cpp|`, with `atol=1e-10`, `rtol=1e-8`. This
+     permits ~`atol` absolute error where the reference is zero/near-zero; the earlier
+     `Δ/(scale+atol)` form was wrong (it forced ~`1e-18` at zero) and is replaced.
+   - **relative backward error** of each internal solve,
+     `||(I-M)x - b||_inf / (||b||_inf + atol) <= 1e-8`, evaluated at a
+     **kernel/linalg-adapter test seam** — not through the public facade, so no debug
+     state is added to `set/calc/get`.
+   Both thresholds are fixed constants in the test module. A tolerance change requires
+   an explicit spec amendment (not an ad-hoc relaxation). The backward-error metric is
+   platform-robust where a raw `allclose` on explicit inverses may not be.
+2. **Reference data.** Existing `.dat`/HDF5 comparisons also run through `numpy`.
+3. **Independent analytical unit tests** (not just C++ as oracle): each formula and
+   each index transform (`Sumfreq_A/B`, `Convert_A2B/B2A`, per-component inverse with
+   fill-in) on small hand-checkable matrices, including **non-commuting blocks** to
+   catch multiplication-order errors and **multi-block / missing-block** (sparse
+   component) cases to catch index permutations and fill-in mistakes. All fixtures use
+   the uniform-dimension invariant (§3.4); non-uniform info is tested only to assert it
+   is **rejected**. Fixtures are constructed well-conditioned (bounded condition
+   number) so agreement thresholds are meaningful.
+4. **Config tests:** `backend` missing (→ `cpp`), wrong case (normalized), invalid
+   value (clear error), and every existing sample TOML still loads unchanged.
+5. **Packaging tests:** build sdist + wheel; `pip install` each into a clean venv
+   *outside* the repo; smoke-test `import chiq`, `import chiq._bse_solver`,
+   `import bse`, extension load, every console-script `--version`/`--help`, and
+   packaged data. Run for each supported Python.
+
+The CuPy skeleton is covered only by a factory test asserting the clear "not enabled"
+error.
+
+## 5. Packaging (pip / scikit-build-core)
+
+### 5.1 Module layout (wheel + editable)
+
+- The pybind11 extension is installed **inside** the package as `chiq._bse_solver`
+  (deterministic in wheels; no reliance on a top-level module or on `PYTHONPATH`).
+  `chiq.solver.cpp` does `from chiq import _bse_solver`.
+- **Top-level `bse_solver` shim**: a tiny pure-Python `bse_solver.py`
+  (`from chiq._bse_solver import *`) preserves `import bse_solver` for one release.
+- **`bse` compatibility**: replace the filesystem *symlink* (unreliable in wheels)
+  with a real shim package `bse/`. **Supported import forms** (the only ones that
+  exist in the current tree, enumerated so the shim is testable): `import bse`,
+  `import bse.<sub>` and `from bse import <sub>` for each existing submodule
+  (`h5bse`, `bse_toml`, `matrix_dict`, `point_group`, `sumk_dft_chi`, `tools`,
+  `index_pair`, `mpi`, …). Implemented as an explicit `bse/__init__.py` that, for each
+  known submodule name, registers `sys.modules['bse.<sub>'] = importlib.import_module
+  ('chiq.<sub>')` and re-exports them — deterministic, import-order-independent, no
+  package-identity guessing. Emits one `DeprecationWarning` on first import; removed in
+  the following release (removal version named in the deprecation message). Covered by
+  module-identity and import-order tests (§4.5).
+
+### 5.2 Entry points
+
+- `console_scripts` for the 10 scripts that already expose `main()`:
+  `chiq_main`, `chiq_post`, `chiq_fft`, `gen_qpath`, `gen_allq`, `calc_Iq`,
+  `calc_Iq_scl`, `plot_chiq_path`, `plot_Ir`, `eigenvec_viewer`.
+- `dcore_chiq.py` currently has only an `__main__` block; extract a `main()` and add
+  its entry point.
+- For one release, the legacy `<name>.py` command spellings are **also** shipped as
+  aliases (documented as deprecated). `chiq_post` imports of `chiq_main` become a
+  package-internal import rather than same-directory script import.
+
+### 5.3 Build backend
+
+- `pyproject.toml` with **scikit-build-core**: `pip install .` (and `-e .`) drives the
+  existing top-level `CMakeLists.txt`, builds `bse_solver`, and lands it as
+  `chiq._bse_solver`. The direct-CMake build path is kept working and **both paths are
+  covered by the §4.5 install tests** so extension destination/RPATH/command set can't
+  silently diverge (Codex risk).
+- **Artifact policy (single source of truth).** The runtime **wheel** contains only
+  genuine runtime resources: the `chiq` package, the `chiq._bse_solver` extension, and
+  `point_group_data` (small, imported at runtime). Test `.h5` fixtures are **excluded
+  from the wheel** and shipped only in the **sdist** (and referenced by the `test`
+  extra / the test tree). Two distinct assertions: the **wheel** smoke test asserts
+  `import chiq`, extension load, and `point_group_data` load (and does *not* look for
+  test `.h5`); the **sdist**/test job asserts the `.h5` fixtures are present and load.
+
+### 5.4 Dependency / Python matrix (pinned)
+
+- `requires-python = ">=3.10"`. CI runs the **full build+ctest+pytest** on `3.10` and
+  `3.13` (the range endpoints), plus a **lightweight wheel/import/backend smoke job**
+  on `3.11` and `3.12`, so the whole advertised range is exercised.
+- Build: `scikit-build-core>=0.10`, `pybind11>=2.12` (2.12+ supports 3.13),
+  `cmake>=3.15`. Runtime deps are pinned by a **per-script import audit**: core =
+  `numpy>=1.23`, `more-itertools`, `h5py` (HDF5 I/O in `h5bse`), `tomli` (only for
+  <3.11; 3.11+ uses stdlib `tomllib`). Optional extras: `mpi[mpi4py]`,
+  `dcore` (χ₀ preprocessing scripts only), `plot[matplotlib]` (plotting scripts only),
+  `test[pytest]`, `gpu[cupy]` (later). Each advertised console script is smoke-tested
+  in the extra that provides its deps.
+- If a verified 3.13 wheel/source build of any dep is not yet available at
+  implementation time, 3.13 drops to "best-effort" in CI and the floor/`3.10` target
+  is unaffected.
+
+### 5.5 MPI note
+
+All ranks import `chiq._bse_solver` and construct the solver identically; `backend`
+comes from the shared TOML so selection is uniform across ranks. No per-rank divergence.
+
+## 6. Rollout / order of work
+
+1. `chiq.solver` package: `layout` + `SolverBase` + `CppSolver`; route `chiq_main.py`
+   through the factory (default `cpp`). Pure refactor — all tests stay green.
+2. `kernels` + `NumpySolver`; backend-agreement + analytical tests; drive cpp↔numpy
+   to tolerance.
+3. `CupySolver` skeleton + factory wiring + "not enabled" test.
+4. pip packaging (pyproject + scikit-build-core + entry points + `bse`/`bse_solver`
+   shims); wheel/sdist install tests; update CI and docs (`README.md`,
+   `doc/install.rst`).
+
+Each step is independently testable and leaves the tree green.
+
+## 7. Later phases (context only, not this spec)
+
+- Phase 1: sparse-ir in χ₀ (`sumk_dft_chi.py`, `dcore_chiq.py`) to remove the
+  fermionic-frequency-cutoff systematic error.
+- Phase 2: enable/tune the CuPy backend on GPU (1 rank/GPU, memory-aware).
+- Phase 3: IR/DLR compression of the BSE internal frequency sum itself.
+
+## 8. Review resolution record (Codex rounds 1–3)
+
+**Reviewer status.** Codex (technical/architecture lens) ran successfully both rounds.
+Antigravity (user/workflow lens) is **non-functional in this environment**: the MCP
+adapter invokes `agy -p --print-timeout 595s` without passing the design as a prompt,
+so it returns an unrelated answer about the `--print-timeout` flag rather than a
+review. Treated as an environment defect, not an approval; the user/workflow lens is
+covered by the author + human review gate instead.
+
+**Round-1 `must_fix_design` — all resolved:** groupwise-inverse invariant + per-
+component solve (§3.5); state machine + per-calc contract (§3.3); canonical layout
+owned by `chiq.solver.layout` (§3.4); ordered formulas, solve orientation, singular
+policy (§3.5); wheel module layout, extension destination, `bse`/`bse_solver` shims,
+entry points, install tests (§5).
+
+**Round-2 `must_fix_design` — all resolved:** vertex-vs-key notation and per-conversion
+key/shape contract (§3.4 table + reductions); uniform-dimension contradiction resolved
+by committing to the uniform invariant and rejecting non-uniform, and dropping the
+self-contradictory uneven-block test (§3.4, §4.3); structural fill-in rule for
+inverse/solve/product matched to `block_matrix.hpp` (§3.5); executable singular-matrix
+policy = all-NaN component, contract scoped to non-singular inputs (§3.5).
+
+**Round-2 `should_fix` absorbed:** stale-output/no-caching policy (§3.3); mixed-layout
+product contract via `ProdAB`/`Sumfreq` key equations (§3.4–3.5); fixed residual/error
+norms and thresholds (§4.1); explicit enumerated `bse` shim import forms (§5.1);
+`CMakeLists.txt` listed as edited for packaging (§3.6, §5.3); 3.11/3.12 smoke jobs and
+per-script dependency audit (§5.4).
+
+**Open questions — dispositions:**
+- *matrix_info_* meaning* → resolved: per-vertex dimension arrays (§3.4).
+- *inverse emits all intra-component pairs?* → resolved: yes, with numerical zeros
+  retained (§3.5).
+- *set-invalidates-outputs?* → accepted: no caching, `set→calc→get` ordering (§3.3).
+- *key ordering / emitted zeros observable?* → resolved: keys are unordered; zeros
+  retained within components; HDF5 write already prunes `|x|<1e-12`
+  (`chiq_main.output2hdf5`), so on-disk output is unchanged (§3.5).
+- *direct-CMake must keep top-level `bse_solver`?* → resolved: both build paths use the
+  one canonical `chiq._bse_solver` layout; top-level name is a Python shim only (§5.1,
+  §5.3).
+- *`backend` TOML round-trip?* → resolved: new optional key in `[chiq_main]`, absent ⇒
+  `cpp`; old parsers/generators that ignore unknown keys are unaffected (§3.2, §4.4).
+
+**Risks — dispositions:**
+- Ill-conditioned explicit inverses (Pq/I_q/Ueff/SCL) → *accepted*: inherent to the
+  established C++ method; contract is equivalence on well-conditioned inputs, and
+  backward-error metrics surface divergence (§4.1). Not introduced by this work.
+- Sparsity-graph closure memory → *mitigated*: per-component solve caps at component
+  size; components are small in ChiQ's block structure. *followup*: revisit if a future
+  physical case yields one giant component (would also affect C++).
+- Absent-key = exact zero assumption → *resolved*: §3.4 states absent ⇒ mathematically
+  forbidden coupling; ChiQ builds dicts by structural rules, not by thresholding, so
+  the assumption holds. Non-uniform/omitted-small-block inputs are rejected.
+- C++ oracle hides shared conceptual errors → *mitigated*: independent analytical unit
+  tests per formula/transform (§4.3).
+- Test HDF5 in runtime wheel bloats size → *resolved*: §5.3 artifact policy — test
+  `.h5` in sdist/test only, excluded from the runtime wheel; only `point_group_data`
+  ships in the wheel; separate wheel vs sdist assertions.
+- One-release deprecation breakage → *resolved*: removal version named in the
+  `DeprecationWarning` for both `bse` and `bse_solver` shims (§5.1, §5.2).
+
+**Round-3 `must_fix_design` — all resolved:**
+- pybind module name → *resolved*: rename `PYBIND11_MODULE(bse_solver→_bse_solver)` so
+  `PyInit__bse_solver` exists and `import chiq._bse_solver` works; top-level
+  `bse_solver` becomes a pure-Python shim (§3.6, §5.1–5.2).
+- tolerance formula error → *resolved*: switched to the standard mixed-tolerance rule
+  `max|Δ| ≤ atol + rtol·max|cpp|` (§4.1).
+- wheel-contents contradiction → *resolved*: single artifact policy with distinct
+  wheel/sdist assertions (§5.3).
+- product key-emission "numerical non-zero" → *resolved*: C++ `operator*` actually
+  emits keys **symbolically** (`exists(i,k) && exists(k,j)`, `block_matrix.hpp:642`),
+  not by value; §3.5 states the exact key-path rule, so the sparsity graph is
+  backend-identical. Codex's premise (value-based) was mistaken; the corrected rule is
+  strictly structural.
+
+Round-3 `should_fix`/questions of note: `Convert_A2B/B2A` full index equations, exact
+exception class for get-before-compute, negative/empty-dimension validation, and upper
+dependency bounds are **deferred to TDD implementation** (they are concrete enough that
+tests will pin them; carrying them as failing tests is more reliable than more prose).
+The layout module's validation and the analytical unit tests (§4.3) are where these
+become executable.

--- a/docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md
+++ b/docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md
@@ -1,7 +1,8 @@
 # Design: NumPy solver backend + backend-switch + pip packaging (Phase 0)
 
 **Date:** 2026-07-12
-**Status:** Ready for human review (incorporates Codex design review rounds 1–4)
+**Status:** Ready for human review (incorporates Codex design review rounds 1–4 + a
+source-grounded Codex code-review pass — see §9)
 **Repo:** ChiQ (Bethe-Salpeter / DMFT momentum-dependent susceptibility solver)
 
 ## 1. Context and goal
@@ -99,6 +100,11 @@ Backends:
 | `gamma0`   | C      | bare vertex                   |
 | `Phi_sum`  | C      | SCL summed vertex (√chi_loc)  |
 
+**calc name case:** `calc()` accepts **both upper- and lower-case** spellings —
+`"BSE"|"bse"`, `"RPA"|"rpa"`, `"RRPA"|"rrpa"`, `"SCL"|"scl"` (and `"chi0"`)
+(`bse_solver_pybind.cpp:114-136`). Both backends accept both cases; the facade does not
+narrow this. (The driver passes lower-case, but the API contract is case-tolerant.)
+
 **calc_type → required set names / produced get names** (from `bse.hpp` `require()`
 calls and `chiq_main.py` worker classes `chi_chi0/chi_bse/chi_rpa/chi_rrpa/chi_scl`):
 
@@ -111,15 +117,31 @@ calls and `chiq_main.py` worker classes `chi_chi0/chi_bse/chi_rpa/chi_rrpa/chi_s
 | `scl`  | X0_q, X0_loc, Phi, Phi_sum        | chi_q_scl, I_q_scl             |
 
 † `chi0_q` for `bse` is produced by a preceding `chi0` calc in the driver, not by
-`CalcChiq_BSE`; the driver's `output_q` lists reflect what is written to HDF5. The
-solver contract is: `get(name)` returns the last computed result of that name and
-raises `KeyError`-style errors if that calc has not run.
+`CalcChiq_BSE`; the driver's `output_q` lists reflect what is written to HDF5.
+
+**`get` before compute → empty dict (not an exception).** The C++ getters return a
+default-constructed `block_matrix` member, which the binding converts to an **empty
+dict `{}`** (`bse_solver_pybind.cpp:160-200`). `get(name)` for a valid-but-not-yet-
+computed name therefore returns `{}`; only an **unknown** name raises
+`RuntimeError("Invalid type '<name>'")`. `NumpySolver` mirrors this exactly (empty dict
+for un-computed valid names). This corrects the earlier "KeyError-style" claim, which
+did not match the C++ backend.
+
+**`I_q` and `I_q_scl` share one result slot.** Both map to `GetIq()`
+(`bse_solver_pybind.cpp:185-190`), which returns the single `Iq` member. `CalcChiq_BSE`
+and `CalcChiq_SCL` both write that same member. So `get("I_q")` and `get("I_q_scl")`
+return whichever irreducible vertex was computed most recently, regardless of which
+name is used. `NumpySolver` uses a single `Iq` slot too, so this hidden aliasing is
+preserved rather than accidentally split into two independent results.
 
 **Lifecycle / error semantics** (match observed C++ behavior):
 - `set` is idempotent-overwrite: setting the same name replaces prior data.
 - `calc` requires all inputs in its row to be set; a missing input raises
-  `RuntimeError("'<name>' must be set before calling calc.")` (mirrors
-  `bse.hpp` `require`).
+  `RuntimeError("'<internal-name>' must be set before calling calc.")` (mirrors
+  `bse.hpp` `require`). **The name in the message is the C++ *internal* name, which is
+  not always the public set name:** missing `X0_loc` reports **`'X0_Loc'`** (capital L,
+  `bse.hpp:225,246,328`); the others match their set names. `NumpySolver` reproduces the
+  exact strings (including `X0_Loc`) so error-message tests are backend-agnostic.
 - Repeated `calc` recomputes from currently-set inputs and overwrites outputs.
 - **No output caching / no auto-invalidation** (matches C++ `BSESolver`, which holds
   inputs by pointer and recomputes on each `calc`): `get` returns the result of the
@@ -162,8 +184,13 @@ blocks are explicitly unsupported in Phase 0.)
 | B      | `v = iw*nb + b`, `iw∈[0,nw)`   | `n_in × n_in`            | `info_B[v]=n_in`  |
 | A      | `v ∈ [0, nb)`                  | `(n_in*nw) × (n_in*nw)`  | `info_A[v]=n_in*nw` |
 
-- B is structurally block-diagonal in `iw`: only keys `(iw*nb+b_i, iw*nb+b_j)`
-  (same `iw`) may be present.
+- B **input** matrices (`X0_loc`, `X0_q`, `Phi`) are structurally block-diagonal in
+  `iw`: only same-`iw` keys `(iw*nb+b_i, iw*nb+b_j)` are present. **Intermediate** B
+  matrices produced by `Convert_A2B` (inside `Prod_A_B` on the BSE path) are **not** so
+  restricted: `Convert_A2B` (`bse.hpp:534-558`) loops `iw1, iw2` independently and can
+  emit **cross-frequency** keys `(iw1*nb+b1, iw2*nb+b2)` with `iw1 ≠ iw2`. The B key
+  domain is therefore the full `[0, nb*nw)²`; only the specific *inputs* above happen to
+  be `iw`-diagonal.
 - A flattens its inner index as `in*nw + iw`.
 - All blocks are **square**; the layout module asserts this and A/B/C mutual
   consistency (`nb, nw, n_in`) on construction, raising on mismatch.
@@ -175,7 +202,12 @@ Reductions/conversions are functions `dict → dict` with the exact key/shape co
 - `Sumfreq_B` (B→C): output key `(b_i,b_j)`;
   `out[(i,j)] = Σ_iw B[(iw*nb+i, iw*nb+j)]` over keys present.
 - `Convert_A2B` (A→B) / `Convert_B2A` (B→A): index remap per `bse.hpp:519-613`;
-  keys and shapes follow the B/A domains above.
+  keys/shapes follow the B/A domains above. **Important:** these two routines are the
+  *one exception* to the "keys are structural" rule — they **prune exactly-zero blocks**
+  via Eigen `isZero(0)` (`bse.hpp:554, 605`), so a converted block is emitted only if it
+  is not identically zero. The NumPy `Convert_*` must reproduce this exact-zero pruning
+  (`if np.any(block != 0)`) so the resulting B/A key sets are backend-identical. (This
+  is exact-zero, not a tolerance, so it is deterministic across backends.)
 
 ### 3.5 Kernel formulas (ordered, matching C++)
 
@@ -218,8 +250,11 @@ Component derivation and fill-in match C++ exactly:
   numerical result. The NumPy `*` reproduces this exact key-path rule, so the output
   sparsity graph is backend-identical regardless of floating-point cancellation.
   Differences (`-`) are entrywise over the union of present keys. Downstream
-  `Sumfreq_*`/`Convert_*`/`get` consume whatever keys are present. No operation ever
-  decides key presence from a numerical zero-test.
+  `Sumfreq_*`/`Convert_*`/`get` consume whatever keys are present. The **only**
+  operations that decide key presence from values are `Convert_A2B`/`Convert_B2A`, and
+  they use an **exact-zero** test (`isZero(0)`) — reproduced verbatim in NumPy (§3.4) so
+  it remains deterministic and backend-identical. `inverse`/`solve`/`*` never test
+  values for key presence.
 
 This is (a) *mathematically identical* to C++ because the full operator is
 block-diagonal across components, and (b) preserves the C++ complexity `Σ_g dim(g)³`,
@@ -269,9 +304,11 @@ Layers:
      `np.all(np.abs(numpy - cpp) <= atol + rtol*np.abs(cpp))` per block, with
      `atol=1e-10`, `rtol=1e-8` (implemented via `np.testing.assert_allclose`, which also
      reports the worst offending element). The scale is `|cpp|` at each position, so a
-     large entry cannot mask an error at a zero/small entry. **NaN/Inf policy:** a
-     position passes only if both backends are non-finite *and equal in the IEEE sense
-     for that kind* (NaN↔NaN, +Inf↔+Inf); any finite-vs-non-finite mismatch fails.
+     large entry cannot mask an error at a zero/small entry. **NaN/Inf policy
+     (explicit):** run `assert_allclose(..., equal_nan=True)` for the finite-tolerance
+     comparison, *preceded* by two boolean masks that must match exactly — NaN positions
+     (`np.isnan`) and signed-infinity positions (`np.isposinf`/`np.isneginf` separately,
+     so `+Inf` vs `−Inf` fails). Any finite-vs-non-finite mismatch fails.
    - **relative backward error** of each internal solve,
      `||(I-M)x - b||_inf / (||b||_inf + atol) <= 1e-8`, evaluated at a
      **kernel/linalg-adapter test seam** — not through the public facade, so no debug
@@ -351,12 +388,17 @@ error.
   `3.13` (the range endpoints), plus a **lightweight wheel/import/backend smoke job**
   on `3.11` and `3.12`, so the whole advertised range is exercised.
 - Build: `scikit-build-core>=0.10`, `pybind11>=2.12` (2.12+ supports 3.13),
-  `cmake>=3.15`. Runtime deps are pinned by a **per-script import audit**: core =
-  `numpy>=1.23`, `more-itertools`, `h5py` (HDF5 I/O in `h5bse`), `tomli` (only for
-  <3.11; 3.11+ uses stdlib `tomllib`). Optional extras: `mpi[mpi4py]`,
-  `dcore` (χ₀ preprocessing scripts only), `plot[matplotlib]` (plotting scripts only),
-  `test[pytest]`, `gpu[cupy]` (later). Each advertised console script is smoke-tested
-  in the extra that provides its deps.
+  `cmake>=3.15`. Runtime deps come from an **actual per-file import audit** (not
+  assumed): core = `numpy>=1.23`, `scipy` (imported by `chiq.g2scl_core` and by the
+  `chiq_fft`/`calc_Iq`/`calc_Iq_scl` scripts), `more-itertools`, `h5py` (HDF5 I/O in
+  `h5bse`), and **`toml`** — `bse_toml.py` imports the third-party `toml` package
+  (read *and* write), **not** `tomllib`/`tomli`; keep `toml` as a core dep (no source
+  migration in Phase 0; `tomllib` is read-only and would require a `dump` replacement).
+  Optional extras (PEP 621 strings pinned in `pyproject.toml`): `mpi` → `mpi4py`,
+  `dcore` → `dcore` (χ₀ preprocessing scripts only), `plot` → `matplotlib` (plotting
+  scripts only), `test` → `pytest`, `gpu` → `cupy` (later). Each advertised console
+  script is smoke-tested in the extra that provides its deps. A CI import-audit step
+  re-derives this list so it cannot silently drift.
 - If a verified 3.13 wheel/source build of any dep is not yet available at
   implementation time, 3.13 drops to "best-effort" in CI and the floor/`3.10` target
   is unaffected.
@@ -486,3 +528,27 @@ must-fix was addressed in-doc. The C++-oracle risk is mitigated by independent
 analytical tests (§4.3); remaining reviewer items are should-fix precision deferred to
 TDD. Antigravity's user/workflow lens was unavailable (environment defect, §8 top), so
 the human review gate substitutes for it.
+
+## 9. Code-review pass resolution (Codex, source-grounded)
+
+A Codex code-review of the diff (reading the actual repository, not just the design)
+surfaced concrete mismatches between the spec and the real C++ behavior that the design
+rounds had missed. All verified against source and fixed in-doc:
+
+- **`Convert_A2B`/`Convert_B2A` cross-frequency keys + exact-zero pruning** → *resolved*:
+  §3.4 now scopes the "same-iw only" invariant to B *inputs*, states the full B key
+  domain for intermediates, and documents that the Convert routines prune `isZero(0)`
+  blocks (the one value-based key decision), reproduced exactly in NumPy (§3.5).
+- **`get` before compute returns `{}`, not an exception** → *resolved*: §3.3 corrected;
+  both backends return an empty dict for un-computed valid names.
+- **calc accepts upper+lower case; missing-`X0_loc` error says `'X0_Loc'`** → *resolved*:
+  §3.3 records the case-tolerant calc names and the exact internal error strings.
+- **`I_q`/`I_q_scl` share one `Iq` slot** → *resolved*: §3.3 documents the aliasing;
+  NumpySolver keeps a single slot.
+- **deps: `toml` (not `tomli`), `scipy` missing** → *resolved*: §5.4 rewritten from an
+  actual per-file import audit; `toml` and `scipy` are core deps; a CI import-audit step
+  prevents drift.
+
+CLAUDE.md was reported "substantially accurate"; no correctness changes required. The
+`recommended_tests` (facade compatibility, analytical key-set tests, clean-env wheel
+installs, import audit) are folded into §4 and will be written as part of TDD.

--- a/docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md
+++ b/docs/superpowers/specs/2026-07-12-numpy-backend-and-packaging-design.md
@@ -1,7 +1,7 @@
 # Design: NumPy solver backend + backend-switch + pip packaging (Phase 0)
 
 **Date:** 2026-07-12
-**Status:** Draft for review (round 3 — incorporates Codex design review rounds 1–3)
+**Status:** Ready for human review (incorporates Codex design review rounds 1–4)
 **Repo:** ChiQ (Bethe-Salpeter / DMFT momentum-dependent susceptibility solver)
 
 ## 1. Context and goal
@@ -242,14 +242,18 @@ existing NaN guard in `chiq_main.output2hdf5` exactly as a C++ inf/nan result wo
   and inline solver construction; drop `_reformat_data`/reshapes now in `layout`),
   `python/package/chiq/bse_toml.py` (parse+validate `backend`).
 - Edit (packaging): `src/bse_solver_pybind.cpp` — rename the module declaration
-  `PYBIND11_MODULE(bse_solver, m)` → `PYBIND11_MODULE(_bse_solver, m)` so the compiled
-  binary exports `PyInit__bse_solver` and is importable as `chiq._bse_solver`. (Only
-  the module name changes; the `BSESolver` class and its bindings are identical.)
-  `src/CMakeLists.txt` / `python/CMakeLists.txt` install the extension into the `chiq`
-  package directory. Both the pip (scikit-build-core) and direct-CMake paths install to
-  the same package-relative location, so `import chiq._bse_solver` works identically
-  (§5.3, verified by §4.5 tests). The top-level name `bse_solver` survives as a
-  pure-Python shim (§5.2).
+  `PYBIND11_MODULE(bse_solver, m)` → `PYBIND11_MODULE(_bse_solver, m)` so the binary
+  exports `PyInit__bse_solver`. **Both must agree:** `src/CMakeLists.txt` currently does
+  `pybind11_add_module(bse_solver ...)`, which names the `.so` `bse_solver.*`. The
+  target is renamed to `_bse_solver` (or given `set_target_properties(... OUTPUT_NAME
+  _bse_solver)`), so the artifact basename is `_bse_solver.<ext>` and exports
+  `PyInit__bse_solver` — the two match and `import chiq._bse_solver` works. (Only the
+  module/target name changes; the `BSESolver` class and bindings are identical.) The
+  extension installs into the `chiq` package directory; both the pip
+  (scikit-build-core) and direct-CMake paths install to the same package-relative
+  location (§5.3, verified by §4.5 tests, which cover installed-tree imports). The
+  top-level name `bse_solver` survives only as a pure-Python shim (§5.2), never as the
+  native artifact.
 
 ## 4. Testing / numerical verification
 
@@ -260,10 +264,14 @@ Layers:
    assert `numpy` == `cpp` on identical input. Two fixed, non-discretionary metrics,
    aggregated as the max over all present blocks (a NaN/Inf in one backend but not the
    other, at the same position, is an immediate failure):
-   - **mixed-tolerance absolute error** (standard `numpy.allclose` convention):
-     `max|cpp - numpy| <= atol + rtol*max|cpp|`, with `atol=1e-10`, `rtol=1e-8`. This
-     permits ~`atol` absolute error where the reference is zero/near-zero; the earlier
-     `Δ/(scale+atol)` form was wrong (it forced ~`1e-18` at zero) and is replaced.
+   - **elementwise mixed tolerance** — the exact `numpy.allclose` rule applied
+     *per element* (not a global scale): assert
+     `np.all(np.abs(numpy - cpp) <= atol + rtol*np.abs(cpp))` per block, with
+     `atol=1e-10`, `rtol=1e-8` (implemented via `np.testing.assert_allclose`, which also
+     reports the worst offending element). The scale is `|cpp|` at each position, so a
+     large entry cannot mask an error at a zero/small entry. **NaN/Inf policy:** a
+     position passes only if both backends are non-finite *and equal in the IEEE sense
+     for that kind* (NaN↔NaN, +Inf↔+Inf); any finite-vs-non-finite mismatch fails.
    - **relative backward error** of each internal solve,
      `||(I-M)x - b||_inf / (||b||_inf + atol) <= 1e-8`, evaluated at a
      **kernel/linalg-adapter test seam** — not through the public facade, so no debug
@@ -452,9 +460,29 @@ per-script dependency audit (§5.4).
   backend-identical. Codex's premise (value-based) was mistaken; the corrected rule is
   strictly structural.
 
-Round-3 `should_fix`/questions of note: `Convert_A2B/B2A` full index equations, exact
-exception class for get-before-compute, negative/empty-dimension validation, and upper
-dependency bounds are **deferred to TDD implementation** (they are concrete enough that
-tests will pin them; carrying them as failing tests is more reliable than more prose).
-The layout module's validation and the analytical unit tests (§4.3) are where these
-become executable.
+**Round-4 `must_fix_design` — both resolved:**
+- agreement metric used a global scale → *resolved*: switched to the **elementwise**
+  `np.allclose` rule (`|Δ| ≤ atol + rtol·|cpp|` per element) with an explicit NaN/Inf
+  policy (§4.1).
+- native artifact filename → *resolved*: rename the CMake target (or set `OUTPUT_NAME`)
+  to `_bse_solver` so the `.so` basename and `PyInit__bse_solver` agree; §4.5 install
+  tests cover installed-tree imports (§3.6).
+
+**Deferred to TDD implementation (should-fix / open questions, by decision):**
+`Convert_A2B/B2A` full index equations; exact exception class+message for
+get-before-compute; empty/zero/negative/non-integer dimension and malformed-key
+validation; the precise `solve(A,B)` block-structure predicate; PEP 621 extras strings
+(`mpi4py`, `matplotlib`, `cupy`, …); the `bse_solver` shim's `DeprecationWarning`
+details; upper dependency bounds; and singular-policy scoping to the numpy/cupy kernels
+(the C++ backend keeps its own native singular behavior — the all-NaN policy is a
+*kernel* policy, not a cross-backend promise). These are concrete enough that the
+layout-module validation and the analytical unit tests (§4.3) pin them as executable
+assertions during implementation; carrying them as failing tests is more reliable than
+further prose. Performance (per-(ω,q) component assembly overhead) is measured by a
+benchmark in the NumpySolver step, not asserted in the spec.
+
+**Convergence note.** Codex must-fix count fell 5→4→4→2 across rounds 1–4; every
+must-fix was addressed in-doc. The C++-oracle risk is mitigated by independent
+analytical tests (§4.3); remaining reviewer items are should-fix precision deferred to
+TDD. Antigravity's user/workflow lens was unavailable (environment defect, §8 top), so
+the human review gate substitutes for it.

--- a/python/package/chiq/bse_toml.py
+++ b/python/package/chiq/bse_toml.py
@@ -42,6 +42,12 @@ def load_params_from_toml(file_name, print_summary=True):
     params = dict_toml["chiq_main"]
     dict_tool["work_dir"] = params.pop("work_dir", "")
     dict_tool["num_wf"] = params.pop("num_wf", None)
+    dict_tool["backend"] = params.pop("backend", "cpp")
+    if str(dict_tool["backend"]).lower() not in ("cpp", "numpy", "cupy"):
+        raise ValueError(
+            f"[chiq_main] backend must be 'cpp', 'numpy', or 'cupy', got "
+            f"{dict_tool['backend']!r}"
+        )
     _obsolete_param(dict_toml, "chiq_main", "solver")
     _check_if_dict_empty(params, block="chiq_main")
 

--- a/python/package/chiq/bse_toml.py
+++ b/python/package/chiq/bse_toml.py
@@ -44,9 +44,9 @@ def load_params_from_toml(file_name, print_summary=True):
     dict_tool["num_wf"] = params.pop("num_wf", None)
     dict_tool["backend"] = params.pop("backend", "cpp")
     if str(dict_tool["backend"]).lower() not in ("cpp", "numpy", "cupy"):
-        raise ValueError(
-            f"[chiq_main] backend must be 'cpp', 'numpy', or 'cupy', got "
-            f"{dict_tool['backend']!r}"
+        sys.exit(
+            f"ERROR: [chiq_main] backend must be 'cpp', 'numpy', or 'cupy', "
+            f"got {dict_tool['backend']!r}"
         )
     _obsolete_param(dict_toml, "chiq_main", "solver")
     _check_if_dict_empty(params, block="chiq_main")

--- a/python/package/chiq/solver/__init__.py
+++ b/python/package/chiq/solver/__init__.py
@@ -1,0 +1,1 @@
+# chiq solver subpackage

--- a/python/package/chiq/solver/__init__.py
+++ b/python/package/chiq/solver/__init__.py
@@ -1,1 +1,23 @@
-# chiq solver subpackage
+"""chiq solver subpackage: backend factory."""
+
+from .base import SolverBase
+
+
+def get_solver(backend, beta, info_A, info_B, info_C):
+    """Return a solver facade for the named backend.
+
+    backend: "cpp" (default in the driver), "numpy", or "cupy".
+    """
+    name = str(backend).lower()
+    if name == "cpp":
+        from .cpp import CppSolver
+        return CppSolver(beta, info_A, info_B, info_C)
+    if name == "numpy":
+        from .numpy import NumpySolver
+        return NumpySolver(beta, info_A, info_B, info_C)
+    if name == "cupy":
+        from .cupy import CupySolver
+        return CupySolver(beta, info_A, info_B, info_C)
+    raise ValueError(
+        f"Unknown backend {backend!r}; expected one of 'cpp', 'numpy', 'cupy'."
+    )

--- a/python/package/chiq/solver/base.py
+++ b/python/package/chiq/solver/base.py
@@ -8,6 +8,8 @@ SET_LAYOUT = {
     "chi_loc": "C", "chi0_loc": "C", "chi0_q": "C", "gamma0": "C", "Phi_sum": "C",
 }
 CALC_TYPES = {"chi0", "bse", "rpa", "rrpa", "scl"}
+# valid get() output names (from bse_solver_pybind.cpp getMatrix)
+GET_NAMES = {"chi0_q", "chi_q", "chi_q_rpa", "chi_q_rrpa", "chi_q_scl", "I_q", "I_q_scl"}
 
 
 class SolverBase(abc.ABC):

--- a/python/package/chiq/solver/base.py
+++ b/python/package/chiq/solver/base.py
@@ -1,0 +1,30 @@
+"""Solver facade base class and shared name tables."""
+
+import abc
+
+# set-name -> layout type
+SET_LAYOUT = {
+    "X_loc": "A", "X0_loc": "B", "X0_q": "B", "Phi": "B",
+    "chi_loc": "C", "chi0_loc": "C", "chi0_q": "C", "gamma0": "C", "Phi_sum": "C",
+}
+CALC_TYPES = {"chi0", "bse", "rpa", "rrpa", "scl"}
+
+
+class SolverBase(abc.ABC):
+    def __init__(self, beta, info_A, info_B, info_C):
+        self.beta = float(beta)
+        self.info_A = list(int(x) for x in info_A)
+        self.info_B = list(int(x) for x in info_B)
+        self.info_C = list(int(x) for x in info_C)
+
+    @abc.abstractmethod
+    def set(self, bm, name):
+        ...
+
+    @abc.abstractmethod
+    def calc(self, calc_type):
+        ...
+
+    @abc.abstractmethod
+    def get(self, name):
+        ...

--- a/python/package/chiq/solver/cpp.py
+++ b/python/package/chiq/solver/cpp.py
@@ -1,0 +1,26 @@
+"""C++ backend: thin wrapper over the pybind module `bse_solver`."""
+
+import numpy as np
+import bse_solver  # top-level pybind module (packaging phase renames to chiq._bse_solver)
+
+from .base import SolverBase
+
+
+class CppSolver(SolverBase):
+    def __init__(self, beta, info_A, info_B, info_C):
+        super().__init__(beta, info_A, info_B, info_C)
+        self._impl = bse_solver.BSESolver(
+            self.beta,
+            np.array(self.info_A),
+            np.array(self.info_B),
+            np.array(self.info_C),
+        )
+
+    def set(self, bm, name):
+        self._impl.set(bm, name)
+
+    def calc(self, calc_type):
+        self._impl.calc(calc_type)
+
+    def get(self, name):
+        return self._impl.get(name)

--- a/python/package/chiq/solver/cupy.py
+++ b/python/package/chiq/solver/cupy.py
@@ -1,0 +1,26 @@
+"""CuPy/GPU backend skeleton. Enabled in a later GPU phase."""
+
+from .base import SolverBase
+
+
+class CupySolver(SolverBase):
+    def __init__(self, beta, info_A, info_B, info_C):
+        super().__init__(beta, info_A, info_B, info_C)
+        raise NotImplementedError(
+            "cupy backend not yet enabled (planned for the GPU phase)."
+        )
+
+    def set(self, bm, name):
+        raise NotImplementedError(
+            "cupy backend not yet enabled (planned for the GPU phase)."
+        )
+
+    def calc(self, calc_type):
+        raise NotImplementedError(
+            "cupy backend not yet enabled (planned for the GPU phase)."
+        )
+
+    def get(self, name):
+        raise NotImplementedError(
+            "cupy backend not yet enabled (planned for the GPU phase)."
+        )

--- a/python/package/chiq/solver/kernels.py
+++ b/python/package/chiq/solver/kernels.py
@@ -34,3 +34,23 @@ def calc_bse(state, beta, nb, nw, n_in):
     Iq = L.sub(L.block_inverse(chi_loc, [n_in] * nb),
                L.block_inverse(chi_q, [n_in] * nb))                  # C-type
     return {"chi_q": chi_q, "I_q": Iq}
+
+
+def calc_rpa(state, beta, nb, nw, n_in):
+    info_C = [n_in] * nb
+    chi0_q = state["chi0_q"]
+    gamma0 = state["gamma0"]
+    m = L.sub(L.identity(info_C), L.matmul(chi0_q, gamma0, info_C))
+    chi_q_rpa = L.matmul(L.block_inverse(m, info_C), chi0_q, info_C)
+    return {"chi_q_rpa": chi_q_rpa}
+
+
+def calc_rrpa(state, beta, nb, nw, n_in):
+    info_C = [n_in] * nb
+    chi0_loc = state["chi0_loc"]
+    chi_loc = state["chi_loc"]
+    chi0_q = state["chi0_q"]
+    Ueff = L.sub(L.block_inverse(chi0_loc, info_C), L.block_inverse(chi_loc, info_C))
+    m = L.sub(L.identity(info_C), L.matmul(chi0_q, Ueff, info_C))
+    chi_q_rrpa = L.matmul(L.block_inverse(m, info_C), chi0_q, info_C)
+    return {"chi_q_rrpa": chi_q_rrpa}

--- a/python/package/chiq/solver/kernels.py
+++ b/python/package/chiq/solver/kernels.py
@@ -1,0 +1,15 @@
+"""The five susceptibility calculations on block matrices (layout ops).
+
+Each returns a dict of named output block matrices. Operation order mirrors
+src/bse.hpp verbatim (explicit block_inverse then matmul) so the results
+agree with the C++ backend within tolerance.
+"""
+
+from . import layout as L
+
+
+def calc_chi0(state, beta, nb, nw, n_in):
+    info_B = [n_in] * (nb * nw)  # noqa: F841 (documents B dims)
+    diff = L.sub(state["X0_q"], state["X0_loc"])
+    chi0_q = L.add(state["chi0_loc"], L.scale(1.0 / beta, L.sumfreq_b(diff, nb, nw, n_in)))
+    return {"chi0_q": chi0_q}

--- a/python/package/chiq/solver/kernels.py
+++ b/python/package/chiq/solver/kernels.py
@@ -13,3 +13,24 @@ def calc_chi0(state, beta, nb, nw, n_in):
     diff = L.sub(state["X0_q"], state["X0_loc"])
     chi0_q = L.add(state["chi0_loc"], L.scale(1.0 / beta, L.sumfreq_b(diff, nb, nw, n_in)))
     return {"chi0_q": chi0_q}
+
+
+def calc_bse(state, beta, nb, nw, n_in):
+    info_A = [n_in * nw] * nb
+    info_B = [n_in] * (nb * nw)  # noqa: F841
+    info_C = [n_in] * nb  # noqa: F841
+    X0_loc = state["X0_loc"]
+    X0_q = state["X0_q"]
+    X_loc = state["X_loc"]
+    chi_loc = state["chi_loc"]
+
+    Pq = L.sub(L.block_inverse(X0_loc, [n_in] * (nb * nw)),
+               L.block_inverse(X0_q, [n_in] * (nb * nw)))            # B-type
+    Xloc_Pq = L.prod_ab(X_loc, Pq, nb, nw, n_in)                     # A-type
+    ident_A = L.identity(info_A)
+    inner = L.sub(L.block_inverse(L.sub(ident_A, Xloc_Pq), info_A), ident_A)  # A-type
+    Zq = L.matmul(inner, X_loc, info_A)                             # A-type
+    chi_q = L.add(chi_loc, L.scale(1.0 / beta, L.sumfreq_a(Zq, nb, nw, n_in)))  # C-type
+    Iq = L.sub(L.block_inverse(chi_loc, [n_in] * nb),
+               L.block_inverse(chi_q, [n_in] * nb))                  # C-type
+    return {"chi_q": chi_q, "I_q": Iq}

--- a/python/package/chiq/solver/kernels.py
+++ b/python/package/chiq/solver/kernels.py
@@ -54,3 +54,22 @@ def calc_rrpa(state, beta, nb, nw, n_in):
     m = L.sub(L.identity(info_C), L.matmul(chi0_q, Ueff, info_C))
     chi_q_rrpa = L.matmul(L.block_inverse(m, info_C), chi0_q, info_C)
     return {"chi_q_rrpa": chi_q_rrpa}
+
+
+def calc_scl(state, beta, nb, nw, n_in):
+    info_B = [n_in] * (nb * nw)
+    info_C = [n_in] * nb
+    X0_loc = state["X0_loc"]
+    X0_q = state["X0_q"]
+    Phi = state["Phi"]
+    Phi_sum = state["Phi_sum"]
+
+    Lambdaq = L.sub(L.block_inverse(X0_loc, info_B), L.block_inverse(X0_q, info_B))  # B
+    lambda_q = L.sumfreq_b(L.matmul(L.matmul(Phi, Lambdaq, info_B), Phi, info_B),
+                           nb, nw, n_in)                                            # C
+    m = L.sub(L.identity(info_C), lambda_q)
+    chi_q_scl = L.matmul(L.matmul(Phi_sum, L.block_inverse(m, info_C), info_C),
+                         Phi_sum, info_C)
+    phisum_inv = L.block_inverse(Phi_sum, info_C)
+    Iq = L.matmul(L.matmul(phisum_inv, lambda_q, info_C), phisum_inv, info_C)
+    return {"chi_q_scl": chi_q_scl, "I_q_scl": Iq}

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -72,3 +72,68 @@ def scale(s, bm):
 def identity(dims):
     """Block-diagonal identity with the given per-vertex dimensions."""
     return {(i, i): np.eye(int(d), dtype=complex) for i, d in enumerate(dims)}
+
+
+def connected_components(bm, nvert):
+    """Connected components of the block-sparsity graph.
+
+    Edge between i and j iff (i,j) or (j,i) is a present key (matches
+    block_matrix.hpp `connected`). Returns a list of components, each a
+    sorted list of vertices, components sorted by their first vertex.
+    """
+    adj = {i: set() for i in range(nvert)}
+    for (i, j) in bm:
+        adj[i].add(j)
+        adj[j].add(i)
+    seen = [False] * nvert
+    comps = []
+    for start in range(nvert):
+        if seen[start]:
+            continue
+        stack = [start]
+        seen[start] = True
+        comp = []
+        while stack:
+            v = stack.pop()
+            comp.append(v)
+            for w in adj[v]:
+                if not seen[w]:
+                    seen[w] = True
+                    stack.append(w)
+        comps.append(sorted(comp))
+    comps.sort(key=lambda c: c[0])
+    return comps
+
+
+def block_inverse(bm, dims):
+    """Per-connected-component dense inverse.
+
+    Assembles each component into a dense super-block, inverts it, and
+    scatters back every intra-component vertex pair (dense fill-in,
+    numerical zeros retained), matching block_matrix.hpp `inverse`.
+    """
+    dims = [int(d) for d in dims]
+    nvert = len(dims)
+    out = {}
+    for comp in connected_components(bm, nvert):
+        offsets = {}
+        size = 0
+        for v in comp:
+            offsets[v] = size
+            size += dims[v]
+        super_block = np.zeros((size, size), dtype=complex)
+        for a in comp:
+            for b in comp:
+                if (a, b) in bm:
+                    super_block[offsets[a]:offsets[a] + dims[a],
+                                offsets[b]:offsets[b] + dims[b]] = bm[(a, b)]
+        with np.errstate(divide="ignore", invalid="ignore"):
+            try:
+                inv = np.linalg.inv(super_block)
+            except np.linalg.LinAlgError:
+                inv = np.full((size, size), np.nan, dtype=complex)
+        for a in comp:
+            for b in comp:
+                out[(a, b)] = inv[offsets[a]:offsets[a] + dims[a],
+                                  offsets[b]:offsets[b] + dims[b]].copy()
+    return out

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -158,3 +158,35 @@ def matmul(a, b, dims):
             if acc is not None:
                 out[(i, j)] = acc
     return out
+
+
+def sumfreq_a(bm, nb, nw, n_in):
+    """A-type -> C-type by summing over both frequency indices.
+
+    out[(i,j)][a,c] = sum_{iw1,iw2} A[(i,j)][a*nw+iw1, c*nw+iw2].
+    Only keys present in bm are emitted (matches Sumfreq_A which skips
+    absent A blocks).
+    """
+    out = {}
+    for (i, j), mat in bm.items():
+        r = mat.reshape(n_in, nw, n_in, nw)
+        out[(i, j)] = r.sum(axis=(1, 3))
+    return out
+
+
+def sumfreq_b(bm, nb, nw, n_in):
+    """B-type -> C-type by summing over the (diagonal) frequency index.
+
+    out[(i,j)] = sum_iw B[(iw*nb+i, iw*nb+j)] over present keys. Every
+    nb*nb key is emitted (matches Sumfreq_B, which assigns all blocks).
+    """
+    out = {}
+    for i in range(nb):
+        for j in range(nb):
+            m = np.zeros((n_in, n_in), dtype=complex)
+            for iw in range(nw):
+                key = (iw * nb + i, iw * nb + j)
+                if key in bm:
+                    m = m + bm[key]
+            out[(i, j)] = m
+    return out

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -213,14 +213,12 @@ def convert_b2a(bm, nb, nw, n_in):
     for b1 in range(nb):
         for b2 in range(nb):
             r = np.zeros((n_in, nw, n_in, nw), dtype=complex)
-            any_nonzero = False
             for iw1 in range(nw):
                 for iw2 in range(nw):
                     key = (iw1 * nb + b1, iw2 * nb + b2)
                     if key in bm:
                         r[:, iw1, :, iw2] = bm[key]
-                        any_nonzero = True
-            if any_nonzero:
+            if np.any(r != 0):
                 out[(b1, b2)] = r.reshape(n_in * nw, n_in * nw)
     return out
 

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -190,3 +190,44 @@ def sumfreq_b(bm, nb, nw, n_in):
                     m = m + bm[key]
             out[(i, j)] = m
     return out
+
+
+def convert_a2b(bm, nb, nw, n_in):
+    """A-type -> B-type. Emits (iw1*nb+b1, iw2*nb+b2) iff the extracted
+    block is not exactly zero (matches Convert_A2B isZero(0) pruning)."""
+    out = {}
+    for (b1, b2), mat in bm.items():
+        r = mat.reshape(n_in, nw, n_in, nw)
+        for iw1 in range(nw):
+            for iw2 in range(nw):
+                block = r[:, iw1, :, iw2]
+                if np.any(block != 0):
+                    out[(iw1 * nb + b1, iw2 * nb + b2)] = block.copy()
+    return out
+
+
+def convert_b2a(bm, nb, nw, n_in):
+    """B-type -> A-type. Emits (b1,b2) iff its assembled A block is not
+    exactly zero (matches Convert_B2A isZero(0) pruning)."""
+    out = {}
+    for b1 in range(nb):
+        for b2 in range(nb):
+            r = np.zeros((n_in, nw, n_in, nw), dtype=complex)
+            any_nonzero = False
+            for iw1 in range(nw):
+                for iw2 in range(nw):
+                    key = (iw1 * nb + b1, iw2 * nb + b2)
+                    if key in bm:
+                        r[:, iw1, :, iw2] = bm[key]
+                        any_nonzero = True
+            if any_nonzero:
+                out[(b1, b2)] = r.reshape(n_in * nw, n_in * nw)
+    return out
+
+
+def prod_ab(a_mat, b_mat, nb, nw, n_in):
+    """A-type * B-type -> A-type, via convert to B, multiply, convert back
+    (reproduces bse.hpp Prod_A_B)."""
+    a_in_b = convert_a2b(a_mat, nb, nw, n_in)
+    ab_in_b = matmul(a_in_b, b_mat, [n_in] * (nb * nw))
+    return convert_b2a(ab_in_b, nb, nw, n_in)

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -36,3 +36,39 @@ def parse_matrix_info(info_A, info_B, info_C):
     if len(info_A) != nb or any(int(x) != n_in * nw for x in info_A):
         raise ValueError("info_A inconsistent with n_in*nw")
     return nb, nw, n_in
+
+
+def add(a, b):
+    """Entrywise a + b over the union of present keys."""
+    out = {}
+    for k in set(a) | set(b):
+        if k in a and k in b:
+            out[k] = a[k] + b[k]
+        elif k in a:
+            out[k] = a[k].copy()
+        else:
+            out[k] = b[k].copy()
+    return out
+
+
+def sub(a, b):
+    """Entrywise a - b over the union of present keys."""
+    out = {}
+    for k in set(a) | set(b):
+        if k in a and k in b:
+            out[k] = a[k] - b[k]
+        elif k in a:
+            out[k] = a[k].copy()
+        else:
+            out[k] = -b[k]
+    return out
+
+
+def scale(s, bm):
+    """Scalar multiply every block by s."""
+    return {k: s * v for k, v in bm.items()}
+
+
+def identity(dims):
+    """Block-diagonal identity with the given per-vertex dimensions."""
+    return {(i, i): np.eye(int(d), dtype=complex) for i, d in enumerate(dims)}

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -1,0 +1,38 @@
+"""Block-matrix algebra for the ChiQ solver backends.
+
+Reproduces the A/B/C block conventions and operations of the C++ solver
+(src/bse.hpp, src/block_matrix.hpp) on dict-of-ndarray block matrices:
+    block matrix := dict[(vi, vj) -> np.ndarray(complex128)]
+Missing key == structural zero. See the design spec section 3.4-3.5.
+"""
+
+import numpy as np
+
+
+def parse_matrix_info(info_A, info_B, info_C):
+    """Return (nb, nw, n_in) from the three matrix-info vectors.
+
+    Enforces the uniform-dimension invariant (same n_in and nw for every
+    block). Raises ValueError on any non-uniform or inconsistent input.
+    """
+    info_A = list(info_A)
+    info_B = list(info_B)
+    info_C = list(info_C)
+    if not info_C:
+        raise ValueError("info_C is empty")
+    nb = len(info_C)
+    n_in = int(info_C[0])
+    if n_in <= 0:
+        raise ValueError(f"non-positive inner dimension {n_in}")
+    if any(int(x) != n_in for x in info_C):
+        raise ValueError("info_C is not uniform")
+    if len(info_B) % nb != 0:
+        raise ValueError("len(info_B) is not a multiple of nb")
+    nw = len(info_B) // nb
+    if nw <= 0:
+        raise ValueError("nw must be positive")
+    if any(int(x) != n_in for x in info_B):
+        raise ValueError("info_B is not uniform (!= n_in)")
+    if len(info_A) != nb or any(int(x) != n_in * nw for x in info_A):
+        raise ValueError("info_A inconsistent with n_in*nw")
+    return nb, nw, n_in

--- a/python/package/chiq/solver/layout.py
+++ b/python/package/chiq/solver/layout.py
@@ -137,3 +137,24 @@ def block_inverse(bm, dims):
                 out[(a, b)] = inv[offsets[a]:offsets[a] + dims[a],
                                   offsets[b]:offsets[b] + dims[b]].copy()
     return out
+
+
+def matmul(a, b, dims):
+    """Block matrix product a @ b.
+
+    Emits key (i,j) iff there exists k with (i,k) in a and (k,j) in b
+    (structural rule, matching block_matrix.hpp operator*); the numerical
+    value never decides key presence.
+    """
+    nvert = len(dims)
+    out = {}
+    for i in range(nvert):
+        for j in range(nvert):
+            acc = None
+            for k in range(nvert):
+                if (i, k) in a and (k, j) in b:
+                    p = a[(i, k)] @ b[(k, j)]
+                    acc = p if acc is None else acc + p
+            if acc is not None:
+                out[(i, j)] = acc
+    return out

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -29,7 +29,7 @@ class NumpySolver(SolverBase):
     def set(self, bm, name):
         if name not in SET_LAYOUT:
             raise RuntimeError(f"Invalid type '{name}'")
-        self._in[name] = {k: np.asarray(v, dtype=complex) for k, v in bm.items()}
+        self._in[name] = {k: np.array(v, dtype=np.complex128, copy=True) for k, v in bm.items()}
 
     def _require(self, calc_type):
         for name in _REQUIRED[calc_type]:
@@ -61,4 +61,4 @@ class NumpySolver(SolverBase):
     def get(self, name):
         if name not in GET_NAMES:
             raise RuntimeError(f"Invalid type '{name}'")
-        return self._out.get(name, {})
+        return {k: v.copy() for k, v in self._out.get(name, {}).items()}

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -1,0 +1,59 @@
+"""NumPy backend: runs the kernels on complex128 block matrices."""
+
+import numpy as np
+
+from . import kernels
+from .base import SolverBase, SET_LAYOUT, CALC_TYPES
+from .layout import parse_matrix_info
+
+# internal require-names used in the C++ error strings (bse.hpp)
+_REQUIRE_NAME = {"X0_loc": "X0_Loc"}  # others equal their set name
+
+# calc_type -> list of required set names (from bse.hpp require() calls)
+_REQUIRED = {
+    "chi0": ["X0_q", "X0_loc", "chi0_loc"],
+    "bse": ["X0_q", "X0_loc", "X_loc", "chi_loc"],
+    "rpa": ["gamma0", "chi0_q"],
+    "rrpa": ["chi0_loc", "chi_loc", "chi0_q"],
+    "scl": ["X0_q", "X0_loc", "Phi", "Phi_sum"],
+}
+
+
+class NumpySolver(SolverBase):
+    def __init__(self, beta, info_A, info_B, info_C):
+        super().__init__(beta, info_A, info_B, info_C)
+        self.nb, self.nw, self.n_in = parse_matrix_info(info_A, info_B, info_C)
+        self._in = {}
+        self._out = {}
+
+    def set(self, bm, name):
+        if name not in SET_LAYOUT:
+            raise RuntimeError(f"Invalid type '{name}'")
+        self._in[name] = {k: np.asarray(v, dtype=complex) for k, v in bm.items()}
+
+    def _require(self, calc_type):
+        for name in _REQUIRED[calc_type]:
+            if name not in self._in:
+                internal = _REQUIRE_NAME.get(name, name)
+                raise RuntimeError(f"'{internal}' must be set before calling calc.")
+
+    def calc(self, calc_type):
+        ct = str(calc_type).lower()
+        if ct not in CALC_TYPES:
+            raise RuntimeError(f"Invalid type '{calc_type}'")
+        self._require(ct)
+        fn = {
+            "chi0": kernels.calc_chi0,
+            # bse/rpa/rrpa/scl added in later tasks
+        }[ct]
+        result = fn(self._in, self.beta, self.nb, self.nw, self.n_in)
+        self._out.update(result)
+        # I_q and I_q_scl are one slot in C++ (both GetIq()): whichever
+        # irreducible vertex was computed most recently answers to both names.
+        if "I_q" in result:
+            self._out["I_q_scl"] = result["I_q"]
+        if "I_q_scl" in result:
+            self._out["I_q"] = result["I_q_scl"]
+
+    def get(self, name):
+        return self._out.get(name, {})

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -47,6 +47,7 @@ class NumpySolver(SolverBase):
             "bse": kernels.calc_bse,
             "rpa": kernels.calc_rpa,
             "rrpa": kernels.calc_rrpa,
+            "scl": kernels.calc_scl,
         }[ct]
         result = fn(self._in, self.beta, self.nb, self.nw, self.n_in)
         self._out.update(result)

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -7,7 +7,7 @@ from .base import SolverBase, SET_LAYOUT, CALC_TYPES, GET_NAMES
 from .layout import parse_matrix_info
 
 # internal require-names used in the C++ error strings (bse.hpp)
-_REQUIRE_NAME = {"X0_loc": "X0_Loc"}  # others equal their set name
+_REQUIRE_NAME = {"X0_loc": "X0_Loc", "Phi_sum": "Phi_Sum"}  # others equal their set name
 
 # calc_type -> list of required set names (from bse.hpp require() calls)
 _REQUIRED = {

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -45,6 +45,8 @@ class NumpySolver(SolverBase):
         fn = {
             "chi0": kernels.calc_chi0,
             "bse": kernels.calc_bse,
+            "rpa": kernels.calc_rpa,
+            "rrpa": kernels.calc_rrpa,
         }[ct]
         result = fn(self._in, self.beta, self.nb, self.nw, self.n_in)
         self._out.update(result)

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from . import kernels
-from .base import SolverBase, SET_LAYOUT, CALC_TYPES
+from .base import SolverBase, SET_LAYOUT, CALC_TYPES, GET_NAMES
 from .layout import parse_matrix_info
 
 # internal require-names used in the C++ error strings (bse.hpp)
@@ -56,4 +56,6 @@ class NumpySolver(SolverBase):
             self._out["I_q"] = result["I_q_scl"]
 
     def get(self, name):
+        if name not in GET_NAMES:
+            raise RuntimeError(f"Invalid type '{name}'")
         return self._out.get(name, {})

--- a/python/package/chiq/solver/numpy.py
+++ b/python/package/chiq/solver/numpy.py
@@ -44,7 +44,7 @@ class NumpySolver(SolverBase):
         self._require(ct)
         fn = {
             "chi0": kernels.calc_chi0,
-            # bse/rpa/rrpa/scl added in later tasks
+            "bse": kernels.calc_bse,
         }[ct]
         result = fn(self._in, self.beta, self.nb, self.nw, self.n_in)
         self._out.update(result)

--- a/python/scripts/chiq_main.py
+++ b/python/scripts/chiq_main.py
@@ -13,8 +13,7 @@ from chiq import __version__ as version
 from chiq import bse_toml
 from chiq import h5bse
 from chiq.mpi import COMM_WORLD as comm
-
-import bse_solver  # shared library implemented with C++
+from chiq.solver import get_solver
 
 
 def get_calc_flg(w_or_q, target_lists, target="w"):
@@ -548,7 +547,7 @@ def main():
                     continue
 
             # BSE solver
-            solver = bse_solver.BSESolver(chi_worker.beta, matinfo_A, matinfo_B, matinfo_C)
+            solver = get_solver(dict_tool["backend"], chi_worker.beta, matinfo_A, matinfo_B, matinfo_C)
 
             # Set local quantities (X_loc, X0_loc, etc)
             bms_local = chi_worker.get_matrix_local(omega)

--- a/tests/python/non-mpi/bsetool_BSE/test_bsetool_BSE.py
+++ b/tests/python/non-mpi/bsetool_BSE/test_bsetool_BSE.py
@@ -26,3 +26,36 @@ def test_chiq(request):
     chiq = read_chiq('chi_q_eigen.dat')
     chiq_ref = read_chiq('ref/chi_q_eigen.dat')
     assert np.allclose(chiq, chiq_ref)
+
+
+def test_chiq_numpy_backend(request):
+    org_dir = os.getcwd()
+    os.chdir(request.fspath.dirname)
+
+    try:
+        shutil.copy('ref/dmft_bse.h5', './')  # overwrite if exists
+
+        # generate a numpy-backend variant of bse.toml
+        with open('bse.toml') as f:
+            toml_text = f.read()
+        toml_text_numpy = toml_text.replace(
+            '[chiq_main]', '[chiq_main]\nbackend = "numpy"'
+        )
+        assert toml_text_numpy != toml_text
+        with open('bse_numpy.toml', 'w') as f:
+            f.write(toml_text_numpy)
+
+        # run
+        assert os.system("chiq_main.py bse_numpy.toml") == 0
+        assert os.system("chiq_post.py bse_numpy.toml") == 0
+
+        # compare results against the same reference the cpp backend matches
+        chi0q = read_chiq('chi0_q_eigen.dat')
+        chi0q_ref = read_chiq('ref/chi0_q_eigen.dat')
+        assert np.allclose(chi0q, chi0q_ref)
+
+        chiq = read_chiq('chi_q_eigen.dat')
+        chiq_ref = read_chiq('ref/chi_q_eigen.dat')
+        assert np.allclose(chiq, chiq_ref)
+    finally:
+        os.chdir(org_dir)

--- a/tests/python/non-mpi/solver/benchmark_backends.py
+++ b/tests/python/non-mpi/solver/benchmark_backends.py
@@ -7,10 +7,11 @@ Not a pytest test (no ``test_`` prefix) -- run it directly:
         python3 tests/python/non-mpi/solver/benchmark_backends.py
 
 For each calc type it builds well-conditioned random inputs of a representative
-size and reports the per-call wall time of each backend and the numpy/cpp ratio.
-The cpp backend uses the compiled (optionally OpenMP-threaded) C++ solver; the
-numpy backend is a single-threaded pure-Python reimplementation, so it is
-expected to be slower -- this script quantifies by how much.
+size ONCE and times both backends on the *same* inputs, reporting the per-call
+wall time of each backend and the numpy/cpp ratio. The cpp backend uses the
+compiled (optionally OpenMP-threaded) C++ solver; the numpy backend is a
+single-threaded pure-Python reimplementation, so it is expected to be slower --
+this script quantifies by how much.
 """
 
 import sys
@@ -30,8 +31,16 @@ def _rand_c(shape):
     return RNG.standard_normal(shape) + 1j * RNG.standard_normal(shape)
 
 
-def _wc(n):  # well-conditioned (diagonally dominant) -> invertible
-    return _rand_c((n, n)) + n * np.eye(n)
+def _wc(n):
+    """A strictly diagonally-dominant (hence invertible) complex matrix.
+
+    Setting each diagonal entry's magnitude above that row's off-diagonal
+    absolute sum guarantees invertibility for any n / seed (Levy-Desplanques).
+    """
+    m = _rand_c((n, n))
+    off = np.abs(m).sum(axis=1) - np.abs(np.diag(m))
+    np.fill_diagonal(m, off + 1.0)
+    return m
 
 
 def _c_full(nb, n_in):
@@ -43,14 +52,16 @@ def _c_wc(nb, n_in):
 
 
 def _b_wc(nb, nw, n_in):
+    # B-type: each same-iw super-block is block-diagonally dominant (invertible)
+    # -- strong diagonal blocks, small off-diagonal blocks.
     out = {}
     for iw in range(nw):
         for b in range(nb):
             for b2 in range(nb):
-                m = _rand_c((n_in, n_in))
                 if b == b2:
-                    m = m + (nb * n_in) * np.eye(n_in)
-                out[(iw * nb + b, iw * nb + b2)] = m
+                    out[(iw * nb + b, iw * nb + b2)] = _wc(n_in) + n_in * np.eye(n_in)
+                else:
+                    out[(iw * nb + b, iw * nb + b2)] = 0.1 * _rand_c((n_in, n_in))
     return out
 
 
@@ -84,17 +95,25 @@ def _inputs(calc, nb, nw, n_in):
     raise ValueError(calc)
 
 
-def _time_one(backend, calc, nb, nw, n_in, repeat):
-    iA, iB, iC = _info(nb, nw, n_in)
-    inputs = _inputs(calc, nb, nw, n_in)
+def _time_calc(backend, calc, inputs, info, repeat):
+    """Best-of-`repeat` wall time of one calc() on the *given* inputs.
+
+    A warm-up call precedes the timed runs so first-use initialization is not
+    charged to either backend. set() is excluded from the timed region.
+    (set() copies its inputs, so the same `inputs` dict is reused for every
+    backend/run without cross-contamination.)
+    """
+    iA, iB, iC = info
     best = float("inf")
-    for _ in range(repeat):
+    for r in range(repeat + 1):  # r == 0 is an untimed warm-up
         s = get_solver(backend, 12.0, iA, iB, iC)
         for name, bm in inputs.items():
             s.set(bm, name)
         t0 = time.perf_counter()
         s.calc(calc)
-        best = min(best, time.perf_counter() - t0)
+        dt = time.perf_counter() - t0
+        if r > 0:
+            best = min(best, dt)
     return best
 
 
@@ -103,14 +122,17 @@ def main():
     sizes = [(1, 20, 2), (2, 20, 2), (2, 40, 2)]
     calcs = ["chi0", "rpa", "rrpa", "bse", "scl"]
     repeat = 3
-    print(f"per-call best-of-{repeat} wall time (one (omega,q) solve), seconds\n")
+    print(f"per-call best-of-{repeat} wall time (one (omega,q) solve), seconds")
+    print("both backends timed on identical inputs; warm-up excluded\n")
     header = f"{'calc':6} {'nb,nw,n_in':>12}  {'cpp [s]':>10} {'numpy [s]':>10} {'numpy/cpp':>10}"
     print(header)
     print("-" * len(header))
     for nb, nw, n_in in sizes:
+        info = _info(nb, nw, n_in)
         for calc in calcs:
-            t_cpp = _time_one("cpp", calc, nb, nw, n_in, repeat)
-            t_np = _time_one("numpy", calc, nb, nw, n_in, repeat)
+            inputs = _inputs(calc, nb, nw, n_in)  # built ONCE, shared by both backends
+            t_cpp = _time_calc("cpp", calc, inputs, info, repeat)
+            t_np = _time_calc("numpy", calc, inputs, info, repeat)
             ratio = t_np / t_cpp if t_cpp > 0 else float("inf")
             print(f"{calc:6} {f'{nb},{nw},{n_in}':>12}  "
                   f"{t_cpp:10.4g} {t_np:10.4g} {ratio:9.1f}x")

--- a/tests/python/non-mpi/solver/benchmark_backends.py
+++ b/tests/python/non-mpi/solver/benchmark_backends.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Speed comparison of the ChiQ solver backends (cpp vs numpy).
+
+Not a pytest test (no ``test_`` prefix) -- run it directly:
+
+    PYTHONPATH="$REPO/python/package:$REPO/build/src" \
+        python3 tests/python/non-mpi/solver/benchmark_backends.py
+
+For each calc type it builds well-conditioned random inputs of a representative
+size and reports the per-call wall time of each backend and the numpy/cpp ratio.
+The cpp backend uses the compiled (optionally OpenMP-threaded) C++ solver; the
+numpy backend is a single-threaded pure-Python reimplementation, so it is
+expected to be slower -- this script quantifies by how much.
+"""
+
+import sys
+import time
+import numpy as np
+
+from chiq.solver import get_solver
+
+RNG = np.random.default_rng(0)
+
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+
+def _rand_c(shape):
+    return RNG.standard_normal(shape) + 1j * RNG.standard_normal(shape)
+
+
+def _wc(n):  # well-conditioned (diagonally dominant) -> invertible
+    return _rand_c((n, n)) + n * np.eye(n)
+
+
+def _c_full(nb, n_in):
+    return {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)}
+
+
+def _c_wc(nb, n_in):
+    return {(i, i): _wc(n_in) for i in range(nb)}
+
+
+def _b_wc(nb, nw, n_in):
+    out = {}
+    for iw in range(nw):
+        for b in range(nb):
+            for b2 in range(nb):
+                m = _rand_c((n_in, n_in))
+                if b == b2:
+                    m = m + (nb * n_in) * np.eye(n_in)
+                out[(iw * nb + b, iw * nb + b2)] = m
+    return out
+
+
+def _b_full(nb, nw, n_in):
+    return {(iw * nb + b, iw * nb + b2): _rand_c((n_in, n_in))
+            for iw in range(nw) for b in range(nb) for b2 in range(nb)}
+
+
+def _a_full(nb, nw, n_in):
+    return {(i, j): _rand_c((n_in * nw, n_in * nw))
+            for i in range(nb) for j in range(nb)}
+
+
+def _inputs(calc, nb, nw, n_in):
+    if calc == "chi0":
+        b = _b_full(nb, nw, n_in)
+        return {"chi0_loc": _c_full(nb, n_in), "X0_loc": b,
+                "X0_q": {k: _rand_c((n_in, n_in)) for k in b}}
+    if calc == "rpa":
+        return {"chi0_q": _c_full(nb, n_in),
+                "gamma0": {(i, i): 0.01 * _rand_c((n_in, n_in)) for i in range(nb)}}
+    if calc == "rrpa":
+        return {"chi0_loc": _c_wc(nb, n_in), "chi_loc": _c_wc(nb, n_in),
+                "chi0_q": _c_full(nb, n_in)}
+    if calc == "bse":
+        return {"X0_loc": _b_wc(nb, nw, n_in), "X0_q": _b_wc(nb, nw, n_in),
+                "X_loc": _a_full(nb, nw, n_in), "chi_loc": _c_wc(nb, n_in)}
+    if calc == "scl":
+        return {"X0_loc": _b_wc(nb, nw, n_in), "X0_q": _b_wc(nb, nw, n_in),
+                "Phi": _b_full(nb, nw, n_in), "Phi_sum": _c_wc(nb, n_in)}
+    raise ValueError(calc)
+
+
+def _time_one(backend, calc, nb, nw, n_in, repeat):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = _inputs(calc, nb, nw, n_in)
+    best = float("inf")
+    for _ in range(repeat):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        t0 = time.perf_counter()
+        s.calc(calc)
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def main():
+    # (nb, nw, n_in): a couple of representative single-q solves.
+    sizes = [(1, 20, 2), (2, 20, 2), (2, 40, 2)]
+    calcs = ["chi0", "rpa", "rrpa", "bse", "scl"]
+    repeat = 3
+    print(f"per-call best-of-{repeat} wall time (one (omega,q) solve), seconds\n")
+    header = f"{'calc':6} {'nb,nw,n_in':>12}  {'cpp [s]':>10} {'numpy [s]':>10} {'numpy/cpp':>10}"
+    print(header)
+    print("-" * len(header))
+    for nb, nw, n_in in sizes:
+        for calc in calcs:
+            t_cpp = _time_one("cpp", calc, nb, nw, n_in, repeat)
+            t_np = _time_one("numpy", calc, nb, nw, n_in, repeat)
+            ratio = t_np / t_cpp if t_cpp > 0 else float("inf")
+            print(f"{calc:6} {f'{nb},{nw},{n_in}':>12}  "
+                  f"{t_cpp:10.4g} {t_np:10.4g} {ratio:9.1f}x")
+        print()
+    print("Note: cpp is the production backend; numpy is single-threaded and "
+          "reproduces the same results (see test_backend_agreement.py).")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/python/non-mpi/solver/test_backend_agreement.py
+++ b/tests/python/non-mpi/solver/test_backend_agreement.py
@@ -123,14 +123,16 @@ def test_bse_agreement(nb, nw, n_in):
         "X_loc": _a_blocks(nb, nw, n_in),
         "chi_loc": _c_blocks_wc(nb, n_in),
     }
-    outs = {}
+    outs_chi, outs_iq = {}, {}
     for backend in ("cpp", "numpy"):
         s = get_solver(backend, 12.0, iA, iB, iC)
         for name, bm in inputs.items():
             s.set(bm, name)
         s.calc("bse")
-        outs[backend] = s.get("chi_q")
-    _assert_agree(outs["cpp"], outs["numpy"])
+        outs_chi[backend] = s.get("chi_q")
+        outs_iq[backend] = s.get("I_q")
+    _assert_agree(outs_chi["cpp"], outs_chi["numpy"])
+    _assert_agree(outs_iq["cpp"], outs_iq["numpy"])
 
 @pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
 def test_scl_agreement(nb, nw, n_in):
@@ -141,11 +143,13 @@ def test_scl_agreement(nb, nw, n_in):
         "Phi": _b_blocks_diag(nb, nw, n_in),
         "Phi_sum": _c_blocks_wc(nb, n_in),
     }
-    outs = {}
+    outs_chi, outs_iq = {}, {}
     for backend in ("cpp", "numpy"):
         s = get_solver(backend, 12.0, iA, iB, iC)
         for name, bm in inputs.items():
             s.set(bm, name)
         s.calc("scl")
-        outs[backend] = s.get("chi_q_scl")
-    _assert_agree(outs["cpp"], outs["numpy"])
+        outs_chi[backend] = s.get("chi_q_scl")
+        outs_iq[backend] = s.get("I_q_scl")
+    _assert_agree(outs_chi["cpp"], outs_chi["numpy"])
+    _assert_agree(outs_iq["cpp"], outs_iq["numpy"])

--- a/tests/python/non-mpi/solver/test_backend_agreement.py
+++ b/tests/python/non-mpi/solver/test_backend_agreement.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pytest
+from chiq.solver import get_solver
+
+RNG = np.random.default_rng(0)
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def _rand_c(shape):
+    return (RNG.standard_normal(shape) + 1j * RNG.standard_normal(shape))
+
+def _well_conditioned(n):
+    # diagonally dominant -> invertible, bounded condition number
+    m = _rand_c((n, n))
+    return m + n * np.eye(n)
+
+def _assert_agree(a, b):
+    for k in set(a) | set(b):
+        if k in a and k in b:
+            va, vb = a[k], b[k]
+        elif k in a:
+            va, vb = a[k], np.zeros_like(a[k])
+        else:
+            va, vb = np.zeros_like(b[k]), b[k]
+        # NaN / signed-inf position masks, then elementwise mixed tolerance.
+        # np.isposinf/np.isneginf reject complex dtype outright (ambiguous
+        # sign), so check real/imag parts separately -- this is a test-harness
+        # fix, not a loosening of the tolerance/metric.
+        va_r, va_i = np.real(va), np.imag(va)
+        vb_r, vb_i = np.real(vb), np.imag(vb)
+        assert np.array_equal(np.isnan(va_r), np.isnan(vb_r))
+        assert np.array_equal(np.isnan(va_i), np.isnan(vb_i))
+        assert np.array_equal(np.isposinf(va_r), np.isposinf(vb_r))
+        assert np.array_equal(np.isposinf(va_i), np.isposinf(vb_i))
+        assert np.array_equal(np.isneginf(va_r), np.isneginf(vb_r))
+        assert np.array_equal(np.isneginf(va_i), np.isneginf(vb_i))
+        np.testing.assert_allclose(va, vb, rtol=1e-8, atol=1e-10, equal_nan=True)
+
+def _c_blocks(nb, n_in):
+    return {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)}
+
+def _c_blocks_wc(nb, n_in):
+    # C-type with well-conditioned diagonal blocks (invertible)
+    d = {(i, i): _well_conditioned(n_in) for i in range(nb)}
+    return d
+
+def _b_blocks_diag(nb, nw, n_in):
+    return {(iw * nb + b, iw * nb + b2): _rand_c((n_in, n_in))
+            for iw in range(nw) for b in range(nb) for b2 in range(nb)}
+
+def _b_blocks_diag_wc(nb, nw, n_in):
+    # B-type well-conditioned in each same-iw super-block (diagonal blocks dominant)
+    out = {}
+    for iw in range(nw):
+        for b in range(nb):
+            for b2 in range(nb):
+                m = _rand_c((n_in, n_in))
+                if b == b2:
+                    m = m + (nb * n_in) * np.eye(n_in)
+                out[(iw * nb + b, iw * nb + b2)] = m
+    return out
+
+def _a_blocks(nb, nw, n_in):
+    return {(i, j): _rand_c((n_in * nw, n_in * nw)) for i in range(nb) for j in range(nb)}
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2), (2, 3, 2)])
+def test_chi0_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = {
+        "chi0_loc": {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)},
+        "X0_loc": {(iw * nb + b, iw * nb + b2): _rand_c((n_in, n_in))
+                   for iw in range(nw) for b in range(nb) for b2 in range(nb)},
+    }
+    inputs["X0_q"] = {k: _rand_c((n_in, n_in)) for k in inputs["X0_loc"]}
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("chi0")
+        outs[backend] = s.get("chi0_q")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_rpa_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    chi0_q = {(i, j): _rand_c((n_in, n_in)) for i in range(nb) for j in range(nb)}
+    gamma0 = {(i, i): 0.01 * _rand_c((n_in, n_in)) for i in range(nb)}
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        s.set(chi0_q, "chi0_q")
+        s.set(gamma0, "gamma0")
+        s.calc("rpa")
+        outs[backend] = s.get("chi_q_rpa")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_rrpa_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = {
+        "chi0_loc": _c_blocks_wc(nb, n_in),
+        "chi_loc": _c_blocks_wc(nb, n_in),
+        "chi0_q": _c_blocks(nb, n_in),
+    }
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("rrpa")
+        outs[backend] = s.get("chi_q_rrpa")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_bse_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    X0_loc = _b_blocks_diag_wc(nb, nw, n_in)
+    inputs = {
+        "X0_loc": X0_loc,
+        "X0_q": _b_blocks_diag_wc(nb, nw, n_in),
+        "X_loc": _a_blocks(nb, nw, n_in),
+        "chi_loc": _c_blocks_wc(nb, n_in),
+    }
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("bse")
+        outs[backend] = s.get("chi_q")
+    _assert_agree(outs["cpp"], outs["numpy"])
+
+@pytest.mark.parametrize("nb,nw,n_in", [(1, 2, 1), (2, 2, 2)])
+def test_scl_agreement(nb, nw, n_in):
+    iA, iB, iC = _info(nb, nw, n_in)
+    inputs = {
+        "X0_loc": _b_blocks_diag_wc(nb, nw, n_in),
+        "X0_q": _b_blocks_diag_wc(nb, nw, n_in),
+        "Phi": _b_blocks_diag(nb, nw, n_in),
+        "Phi_sum": _c_blocks_wc(nb, n_in),
+    }
+    outs = {}
+    for backend in ("cpp", "numpy"):
+        s = get_solver(backend, 12.0, iA, iB, iC)
+        for name, bm in inputs.items():
+            s.set(bm, name)
+        s.calc("scl")
+        outs[backend] = s.get("chi_q_scl")
+    _assert_agree(outs["cpp"], outs["numpy"])

--- a/tests/python/non-mpi/solver/test_bse_toml_backend.py
+++ b/tests/python/non-mpi/solver/test_bse_toml_backend.py
@@ -1,0 +1,51 @@
+"""Tests for the `[chiq_main] backend` option parsed by bse_toml.
+
+`load_params_from_toml` is a CLI-only helper (called by chiq_main.py /
+chiq_post.py); on an invalid `backend` it exits the process via ``sys.exit``
+(matching the sibling ``_check_if_dict_empty`` convention), so an invalid value
+raises ``SystemExit`` rather than ``ValueError``.
+"""
+
+import textwrap
+
+import pytest
+
+from chiq import bse_toml
+
+
+def _write_toml(tmp_path, backend_line):
+    text = textwrap.dedent(
+        f"""
+        [chiq_common]
+        input = "dmft_bse.h5"
+        type = ["chi0"]
+
+        [chiq_main]
+        {backend_line}
+
+        [chiq_post]
+        """
+    )
+    p = tmp_path / "bse.toml"
+    p.write_text(text)
+    return str(p)
+
+
+def test_default_backend_is_cpp(tmp_path):
+    toml = _write_toml(tmp_path, "")  # no backend key
+    _, dict_tool, _ = bse_toml.load_params_from_toml(toml, print_summary=False)
+    assert dict_tool["backend"] == "cpp"
+
+
+@pytest.mark.parametrize("backend", ["cpp", "numpy", "cupy"])
+def test_valid_backends_parse(tmp_path, backend):
+    toml = _write_toml(tmp_path, f'backend = "{backend}"')
+    _, dict_tool, _ = bse_toml.load_params_from_toml(toml, print_summary=False)
+    assert dict_tool["backend"] == backend
+
+
+def test_invalid_backend_exits(tmp_path):
+    toml = _write_toml(tmp_path, 'backend = "gpu999"')
+    with pytest.raises(SystemExit) as exc:
+        bse_toml.load_params_from_toml(toml, print_summary=False)
+    assert "backend must be" in str(exc.value)

--- a/tests/python/non-mpi/solver/test_cupy_skeleton.py
+++ b/tests/python/non-mpi/solver/test_cupy_skeleton.py
@@ -1,0 +1,7 @@
+import pytest
+from chiq.solver import get_solver
+
+def test_cupy_backend_not_enabled():
+    with pytest.raises((NotImplementedError, ImportError, RuntimeError)) as exc:
+        get_solver("cupy", 10.0, [2], [1, 1], [1])
+    assert "cupy" in str(exc.value).lower()

--- a/tests/python/non-mpi/solver/test_factory_cpp.py
+++ b/tests/python/non-mpi/solver/test_factory_cpp.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+from chiq.solver import get_solver
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def test_factory_returns_cpp_by_default_and_runs_chi0():
+    nb, nw, n_in = 1, 2, 1
+    iA, iB, iC = _info(nb, nw, n_in)
+    solver = get_solver("cpp", beta=10.0, info_A=iA, info_B=iB, info_C=iC)
+    # minimal chi0 inputs
+    solver.set({(0, 0): np.zeros((n_in, n_in), dtype=complex)}, "chi0_loc")
+    solver.set({(0, 0): np.zeros((n_in, n_in), dtype=complex), (1, 1): np.zeros((n_in, n_in), dtype=complex)}, "X0_loc")
+    solver.set({(0, 0): np.zeros((n_in, n_in), dtype=complex), (1, 1): np.zeros((n_in, n_in), dtype=complex)}, "X0_q")
+    solver.calc("chi0")
+    out = solver.get("chi0_q")
+    assert isinstance(out, dict)
+
+def test_factory_rejects_unknown_backend():
+    iA, iB, iC = _info(1, 2, 1)
+    with pytest.raises(ValueError):
+        get_solver("gpu999", 10.0, iA, iB, iC)

--- a/tests/python/non-mpi/solver/test_layout_convert.py
+++ b/tests/python/non-mpi/solver/test_layout_convert.py
@@ -26,3 +26,10 @@ def test_prod_ab_matches_dense():
     # dense: convert A to B (full 2x2 in freq), multiply by diag(2,5), convert back
     Bdense = np.diag([2.0, 5.0]).astype(complex)
     assert np.allclose(got[(0, 0)], A @ Bdense)
+
+def test_convert_b2a_prunes_present_but_zero_block():
+    # a B key that is present but exactly zero must NOT produce an A block
+    # (C++ Convert_B2A prunes on the assembled value via isZero(0), not on key presence)
+    B = {(0, 0): np.zeros((1, 1), dtype=complex)}
+    out = layout.convert_b2a(B, nb=1, nw=2, n_in=1)
+    assert out == {}

--- a/tests/python/non-mpi/solver/test_layout_convert.py
+++ b/tests/python/non-mpi/solver/test_layout_convert.py
@@ -1,0 +1,28 @@
+import numpy as np
+from chiq.solver import layout
+
+def test_a2b_b2a_roundtrip():
+    nb, nw, n_in = 1, 2, 1
+    A = np.array([[1, 2], [3, 4]], dtype=complex)  # in*nw+iw indexing, n_in=1
+    a = {(0, 0): A}
+    b = layout.convert_a2b(a, nb, nw, n_in)
+    # keys are (iw1*nb+0, iw2*nb+0) for nonzero extracted entries
+    assert (0, 0) in b and (1, 1) in b  # A[0,0]=1, A[1,1]=4
+    back = layout.convert_b2a(b, nb, nw, n_in)
+    assert np.allclose(back[(0, 0)], A)
+
+def test_a2b_prunes_exact_zero_blocks():
+    nb, nw, n_in = 1, 2, 1
+    A = np.array([[1, 0], [0, 4]], dtype=complex)
+    b = layout.convert_a2b({(0, 0): A}, nb, nw, n_in)
+    assert set(b) == {(0, 0), (1, 1)}  # cross-freq (0,1),(1,0) are exactly zero -> pruned
+
+def test_prod_ab_matches_dense():
+    nb, nw, n_in = 1, 2, 1
+    A = np.array([[1, 2], [3, 4]], dtype=complex)
+    # B-type diagonal in iw: keys (iw,iw)
+    Bmat = {(0, 0): np.array([[2]], dtype=complex), (1, 1): np.array([[5]], dtype=complex)}
+    got = layout.prod_ab(A_as := {(0, 0): A}, Bmat, nb, nw, n_in)
+    # dense: convert A to B (full 2x2 in freq), multiply by diag(2,5), convert back
+    Bdense = np.diag([2.0, 5.0]).astype(complex)
+    assert np.allclose(got[(0, 0)], A @ Bdense)

--- a/tests/python/non-mpi/solver/test_layout_elementwise.py
+++ b/tests/python/non-mpi/solver/test_layout_elementwise.py
@@ -1,0 +1,26 @@
+import numpy as np
+from chiq.solver import layout
+
+def _blk(v):
+    return np.array([[v]], dtype=complex)
+
+def test_sub_union_of_keys():
+    a = {(0, 0): _blk(3), (0, 1): _blk(2)}
+    b = {(0, 0): _blk(1), (1, 1): _blk(5)}
+    r = layout.sub(a, b)
+    assert set(r) == {(0, 0), (0, 1), (1, 1)}
+    assert r[(0, 0)] == _blk(2)
+    assert r[(0, 1)] == _blk(2)
+    assert r[(1, 1)] == _blk(-5)
+
+def test_add_and_scale():
+    a = {(0, 0): _blk(3)}
+    b = {(0, 0): _blk(1)}
+    assert layout.add(a, b)[(0, 0)] == _blk(4)
+    assert layout.scale(2.0, a)[(0, 0)] == _blk(6)
+
+def test_identity():
+    ident = layout.identity([2, 1])
+    assert set(ident) == {(0, 0), (1, 1)}
+    assert np.array_equal(ident[(0, 0)], np.eye(2, dtype=complex))
+    assert np.array_equal(ident[(1, 1)], np.eye(1, dtype=complex))

--- a/tests/python/non-mpi/solver/test_layout_elementwise.py
+++ b/tests/python/non-mpi/solver/test_layout_elementwise.py
@@ -24,3 +24,38 @@ def test_identity():
     assert set(ident) == {(0, 0), (1, 1)}
     assert np.array_equal(ident[(0, 0)], np.eye(2, dtype=complex))
     assert np.array_equal(ident[(1, 1)], np.eye(1, dtype=complex))
+
+def test_add_asymmetric_branches():
+    """Test add with asymmetric operands: keys present in only one operand."""
+    a = {(0, 0): _blk(3), (0, 1): _blk(2)}
+    b = {(0, 0): _blk(1), (1, 1): _blk(5)}
+    r = layout.add(a, b)
+    assert set(r) == {(0, 0), (0, 1), (1, 1)}
+    # (0, 0) present in both: 3 + 1 = 4
+    assert r[(0, 0)] == _blk(4)
+    # (0, 1) present in a only: copy of a's block
+    assert r[(0, 1)] == _blk(2)
+    # (1, 1) present in b only: copy of b's block
+    assert r[(1, 1)] == _blk(5)
+
+def test_add_sub_do_not_mutate_inputs():
+    """Test that add and sub do not mutate their input operands."""
+    # Test add
+    a = {(0, 0): _blk(3)}
+    b = {(0, 0): _blk(1)}
+    r = layout.add(a, b)
+    # Mutate the returned block
+    r[(0, 0)][0, 0] = 999
+    # Verify inputs are unchanged
+    assert a[(0, 0)][0, 0] == 3
+    assert b[(0, 0)][0, 0] == 1
+
+    # Test sub
+    a = {(0, 0): _blk(3)}
+    b = {(0, 0): _blk(1)}
+    r = layout.sub(a, b)
+    # Mutate the returned block
+    r[(0, 0)][0, 0] = 999
+    # Verify inputs are unchanged
+    assert a[(0, 0)][0, 0] == 3
+    assert b[(0, 0)][0, 0] == 1

--- a/tests/python/non-mpi/solver/test_layout_info.py
+++ b/tests/python/non-mpi/solver/test_layout_info.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+from chiq.solver import layout
+
+def test_parse_matrix_info_uniform():
+    nb, nw, n_in = 2, 3, 4
+    info_A = [n_in * nw] * nb
+    info_B = [n_in] * (nb * nw)
+    info_C = [n_in] * nb
+    assert layout.parse_matrix_info(info_A, info_B, info_C) == (nb, nw, n_in)
+
+def test_parse_matrix_info_rejects_nonuniform_inner():
+    with pytest.raises(ValueError):
+        layout.parse_matrix_info([8, 8], [4, 4, 5, 4], [4, 4])  # info_B not all equal
+
+def test_parse_matrix_info_rejects_bad_A_dim():
+    # nb=2, nw=2, n_in=4 -> info_A must be [8,8]; give [9,9]
+    with pytest.raises(ValueError):
+        layout.parse_matrix_info([9, 9], [4, 4, 4, 4], [4, 4])

--- a/tests/python/non-mpi/solver/test_layout_inverse.py
+++ b/tests/python/non-mpi/solver/test_layout_inverse.py
@@ -1,0 +1,31 @@
+import numpy as np
+from chiq.solver import layout
+
+def test_connected_components_two_islands():
+    bm = {(0, 0): np.eye(1) * 1, (2, 2): np.eye(1) * 1, (0, 2): np.eye(1) * 0.0 + 1}
+    # vertices 0 and 2 are connected via (0,2); vertex 1 isolated
+    comps = layout.connected_components(bm, nvert=3)
+    assert comps == [[0, 2], [1]]
+
+def test_block_inverse_matches_dense_and_fills_in():
+    # single 2-vertex component; inverse is generally full within the component
+    a = np.array([[2, 1], [0, 3]], dtype=complex)
+    b = np.array([[1, 0], [1, 1]], dtype=complex)
+    c = np.array([[4, 0], [0, 2]], dtype=complex)
+    d = np.array([[1, 2], [0, 1]], dtype=complex)
+    bm = {(0, 0): a, (0, 1): b, (1, 0): c, (1, 1): d}
+    inv = layout.block_inverse(bm, dims=[2, 2])
+    # reconstruct dense 4x4 and compare
+    big = np.block([[a, b], [c, d]])
+    big_inv = np.linalg.inv(big)
+    got = np.block([[inv[(0, 0)], inv[(0, 1)]], [inv[(1, 0)], inv[(1, 1)]]])
+    assert np.allclose(got, big_inv)
+    # fill-in: all 4 intra-component pairs present
+    assert set(inv) == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+def test_block_inverse_keeps_components_separate():
+    bm = {(0, 0): np.array([[2]], dtype=complex), (1, 1): np.array([[4]], dtype=complex)}
+    inv = layout.block_inverse(bm, dims=[1, 1])
+    assert set(inv) == {(0, 0), (1, 1)}
+    assert np.allclose(inv[(0, 0)], [[0.5]])
+    assert np.allclose(inv[(1, 1)], [[0.25]])

--- a/tests/python/non-mpi/solver/test_layout_inverse.py
+++ b/tests/python/non-mpi/solver/test_layout_inverse.py
@@ -29,3 +29,22 @@ def test_block_inverse_keeps_components_separate():
     assert set(inv) == {(0, 0), (1, 1)}
     assert np.allclose(inv[(0, 0)], [[0.5]])
     assert np.allclose(inv[(1, 1)], [[0.25]])
+
+def test_block_inverse_singular_gives_nan():
+    bm = {(0, 0): np.zeros((2, 2), dtype=complex)}
+    inv = layout.block_inverse(bm, dims=[2])
+    assert set(inv) == {(0, 0)}
+    assert np.isnan(inv[(0, 0)]).all()
+
+def test_block_inverse_fills_absent_intra_component_key():
+    a = np.array([[2.0]], dtype=complex)
+    c = np.array([[1.0]], dtype=complex)   # (1,0) present -> vertices 0,1 connected
+    d = np.array([[3.0]], dtype=complex)
+    bm = {(0, 0): a, (1, 0): c, (1, 1): d}   # (0,1) ABSENT in input
+    inv = layout.block_inverse(bm, dims=[1, 1])
+    assert (0, 1) in inv   # fill-in added the absent key
+    # compare to dense inverse treating missing (0,1) as zero
+    big = np.block([[a, np.zeros((1, 1), complex)], [c, d]])
+    big_inv = np.linalg.inv(big)
+    got = np.block([[inv[(0, 0)], inv[(0, 1)]], [inv[(1, 0)], inv[(1, 1)]]])
+    assert np.allclose(got, big_inv)

--- a/tests/python/non-mpi/solver/test_layout_matmul.py
+++ b/tests/python/non-mpi/solver/test_layout_matmul.py
@@ -1,0 +1,21 @@
+import numpy as np
+from chiq.solver import layout
+
+def test_matmul_structural_keys_and_values():
+    a = {(0, 0): np.array([[1, 2], [3, 4]], dtype=complex),
+         (0, 1): np.array([[1, 0], [0, 1]], dtype=complex)}
+    b = {(0, 0): np.array([[1, 0], [0, 1]], dtype=complex),
+         (1, 1): np.array([[2, 0], [0, 2]], dtype=complex)}
+    r = layout.matmul(a, b, dims=[2, 2])
+    # (0,0): a00@b00 ; (0,1): a01@b11 ; nothing writes (1,*)
+    assert set(r) == {(0, 0), (0, 1)}
+    assert np.allclose(r[(0, 0)], a[(0, 0)])
+    assert np.allclose(r[(0, 1)], 2 * np.eye(2))
+
+def test_matmul_noncommuting():
+    x = np.array([[0, 1], [0, 0]], dtype=complex)
+    y = np.array([[0, 0], [1, 0]], dtype=complex)
+    a = {(0, 0): x}
+    b = {(0, 0): y}
+    assert np.allclose(layout.matmul(a, b, [2])[(0, 0)], x @ y)
+    assert not np.allclose(x @ y, y @ x)

--- a/tests/python/non-mpi/solver/test_layout_matmul.py
+++ b/tests/python/non-mpi/solver/test_layout_matmul.py
@@ -19,3 +19,11 @@ def test_matmul_noncommuting():
     b = {(0, 0): y}
     assert np.allclose(layout.matmul(a, b, [2])[(0, 0)], x @ y)
     assert not np.allclose(x @ y, y @ x)
+
+def test_matmul_emits_key_with_cancelled_zero_value():
+    # (0,0) = a[0,0]@b[0,0] + a[0,1]@b[1,0] = 1*1 + 1*(-1) = 0, but structurally present.
+    a = {(0, 0): np.array([[1.0]], dtype=complex), (0, 1): np.array([[1.0]], dtype=complex)}
+    b = {(0, 0): np.array([[1.0]], dtype=complex), (1, 0): np.array([[-1.0]], dtype=complex)}
+    r = layout.matmul(a, b, dims=[1, 1])
+    assert (0, 0) in r                      # emitted despite value == 0
+    assert np.allclose(r[(0, 0)], [[0.0]])  # value is a genuine zero

--- a/tests/python/non-mpi/solver/test_layout_sumfreq.py
+++ b/tests/python/non-mpi/solver/test_layout_sumfreq.py
@@ -20,3 +20,30 @@ def test_sumfreq_a_sums_over_both_frequency_indices():
     out = layout.sumfreq_a(bm, nb, nw, n_in)
     assert set(out) == {(0, 0)}
     assert np.allclose(out[(0, 0)], [[1 + 2 + 3 + 4]])
+
+def test_sumfreq_a_multiorbital_reshape_order():
+    # n_in=2, nw=2 -> A block is 4x4; distinguishes a*nw+iw from the transposed iw*n_in+a.
+    nb, nw, n_in = 1, 2, 2
+    A = np.arange(16, dtype=complex).reshape(4, 4)
+    bm = {(0, 0): A}
+    out = layout.sumfreq_a(bm, nb, nw, n_in)
+    # explicit reference: expected[a,c] = sum over iw1,iw2 of A[a*nw+iw1, c*nw+iw2]
+    expected = np.zeros((n_in, n_in), dtype=complex)
+    for a in range(n_in):
+        for c in range(n_in):
+            for iw1 in range(nw):
+                for iw2 in range(nw):
+                    expected[a, c] += A[a * nw + iw1, c * nw + iw2]
+    assert np.allclose(out[(0, 0)], expected)
+
+def test_sumfreq_b_offdiagonal_multiorbital():
+    # n_in=2, nb=2, nw=2: off-diagonal (i!=j) blocks summed over iw.
+    nb, nw, n_in = 2, 2, 2
+    b0 = np.arange(4, dtype=complex).reshape(2, 2)
+    b1 = 10 + np.arange(4, dtype=complex).reshape(2, 2)
+    # key (iw*nb + i, iw*nb + j) with i=0, j=1
+    bm = {(0 * nb + 0, 0 * nb + 1): b0, (1 * nb + 0, 1 * nb + 1): b1}
+    out = layout.sumfreq_b(bm, nb, nw, n_in)
+    assert set(out) == {(i, j) for i in range(nb) for j in range(nb)}
+    assert np.allclose(out[(0, 1)], b0 + b1)
+    assert np.allclose(out[(0, 0)], np.zeros((n_in, n_in)))

--- a/tests/python/non-mpi/solver/test_layout_sumfreq.py
+++ b/tests/python/non-mpi/solver/test_layout_sumfreq.py
@@ -1,0 +1,22 @@
+import numpy as np
+from chiq.solver import layout
+
+def test_sumfreq_b_sums_over_frequency_and_emits_all_keys():
+    nb, nw, n_in = 2, 2, 1
+    bm = {}
+    # only diagonal (i==j) same-iw keys present
+    bm[(0 * nb + 0, 0 * nb + 0)] = np.array([[1.0]], dtype=complex)
+    bm[(1 * nb + 0, 1 * nb + 0)] = np.array([[3.0]], dtype=complex)  # iw=1, b=0
+    out = layout.sumfreq_b(bm, nb, nw, n_in)
+    assert set(out) == {(i, j) for i in range(nb) for j in range(nb)}
+    assert np.allclose(out[(0, 0)], [[4.0]])  # 1 + 3
+    assert np.allclose(out[(0, 1)], [[0.0]])
+
+def test_sumfreq_a_sums_over_both_frequency_indices():
+    nb, nw, n_in = 1, 2, 1
+    # A block is (n_in*nw)=(2) x 2; inner flattened as in*nw+iw -> here in=0 so index==iw
+    A = np.array([[1, 2], [3, 4]], dtype=complex)
+    bm = {(0, 0): A}
+    out = layout.sumfreq_a(bm, nb, nw, n_in)
+    assert set(out) == {(0, 0)}
+    assert np.allclose(out[(0, 0)], [[1 + 2 + 3 + 4]])

--- a/tests/python/non-mpi/solver/test_numpy_bse.py
+++ b/tests/python/non-mpi/solver/test_numpy_bse.py
@@ -1,0 +1,30 @@
+import numpy as np
+from chiq.solver import get_solver
+from chiq.solver.kernels import calc_bse
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def test_iq_and_iq_scl_share_one_slot():
+    # After a bse calc, get("I_q_scl") returns the same value as get("I_q").
+    nb, nw, n_in = 1, 2, 1
+    s = get_solver("numpy", 5.0, *_info(nb, nw, n_in))
+    X0 = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[2.0]], complex)}
+    s.set(X0, "X0_q")
+    s.set(X0, "X0_loc")
+    s.set({(0, 0): np.eye(2, dtype=complex)}, "X_loc")
+    s.set({(0, 0): np.array([[3.0]], complex)}, "chi_loc")
+    s.calc("bse")
+    assert s.get("I_q_scl") == s.get("I_q")
+
+def test_bse_reduces_to_chi_loc_when_X0q_equals_X0loc():
+    # If X0_q == X0_loc then P_q = 0, Z_q = 0, so chi_q == chi_loc.
+    nb, nw, n_in, beta = 1, 2, 1, 5.0
+    X0 = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[2.0]], complex)}
+    X_loc = {(0, 0): np.array([[1.0, 0.0], [0.0, 1.0]], complex)}  # A-type 2x2
+    chi_loc = {(0, 0): np.array([[3.0]], complex)}
+    state = {"X0_q": X0, "X0_loc": X0, "X_loc": X_loc, "chi_loc": chi_loc}
+    out = calc_bse(state, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q"][(0, 0)], [[3.0]])
+    # I_q = chi_loc^-1 - chi_q^-1 = 0 here
+    assert np.allclose(out["I_q"][(0, 0)], [[0.0]])

--- a/tests/python/non-mpi/solver/test_numpy_chi0.py
+++ b/tests/python/non-mpi/solver/test_numpy_chi0.py
@@ -1,0 +1,14 @@
+import numpy as np
+from chiq.solver import get_solver
+
+def test_chi0_formula_one_block():
+    # nb=1, nw=1, n_in=1, beta given; chi0_q = chi0_loc + (1/beta)*(X0_q - X0_loc)
+    beta = 4.0
+    iA, iB, iC = [1], [1], [1]
+    s = get_solver("numpy", beta, iA, iB, iC)
+    s.set({(0, 0): np.array([[7.0]], complex)}, "chi0_loc")
+    s.set({(0, 0): np.array([[2.0]], complex)}, "X0_loc")
+    s.set({(0, 0): np.array([[10.0]], complex)}, "X0_q")
+    s.calc("chi0")
+    out = s.get("chi0_q")
+    assert np.allclose(out[(0, 0)], [[7.0 + (10.0 - 2.0) / beta]])

--- a/tests/python/non-mpi/solver/test_numpy_facade.py
+++ b/tests/python/non-mpi/solver/test_numpy_facade.py
@@ -21,6 +21,17 @@ def test_missing_input_reports_capital_X0_Loc():
     with pytest.raises(RuntimeError, match="'X0_Loc' must be set"):
         s.calc("chi0")
 
+def test_missing_phi_sum_reports_capital_Phi_Sum():
+    # SCL requires X0_q, X0_loc, Phi, Phi_sum; omit Phi_sum -> error names 'Phi_Sum' (capital S), matching C++.
+    nb, nw, n_in = 1, 2, 1
+    s = get_solver("numpy", 10.0, *_info(nb, nw, n_in))
+    X0 = {(0, 0): np.zeros((n_in, n_in), complex), (1, 1): np.zeros((n_in, n_in), complex)}
+    s.set(X0, "X0_q")
+    s.set(X0, "X0_loc")
+    s.set(X0, "Phi")
+    with pytest.raises(RuntimeError, match="'Phi_Sum' must be set"):
+        s.calc("scl")
+
 def test_get_unknown_name_raises():
     s = get_solver("numpy", 10.0, *_info(1, 2, 1))
     with pytest.raises(RuntimeError, match="Invalid type"):

--- a/tests/python/non-mpi/solver/test_numpy_facade.py
+++ b/tests/python/non-mpi/solver/test_numpy_facade.py
@@ -40,3 +40,29 @@ def test_get_unknown_name_raises():
 def test_get_valid_uncomputed_name_returns_empty_dict():
     s = get_solver("numpy", 10.0, *_info(1, 2, 1))
     assert s.get("chi_q") == {}   # valid output name, not computed yet -> {}
+
+def test_set_copies_input_no_aliasing():
+    # mutating the caller's array after set() must not change the stored input / results
+    nb, nw, n_in, beta = 1, 1, 1, 4.0
+    s = get_solver("numpy", beta, [1], [1], [1])
+    chi0_loc = {(0, 0): np.array([[7.0]], complex)}
+    X0_loc = {(0, 0): np.array([[2.0]], complex)}
+    X0_q = {(0, 0): np.array([[10.0]], complex)}
+    s.set(chi0_loc, "chi0_loc"); s.set(X0_loc, "X0_loc"); s.set(X0_q, "X0_q")
+    X0_q[(0, 0)][0, 0] = 999.0   # mutate caller's array AFTER set
+    s.calc("chi0")
+    out = s.get("chi0_q")
+    # result uses the value at set() time (10.0), not the mutated 999.0
+    assert np.allclose(out[(0, 0)], [[7.0 + (10.0 - 2.0) / beta]])
+
+def test_get_returns_owned_copy_no_aliasing():
+    nb, nw, n_in, beta = 1, 1, 1, 4.0
+    s = get_solver("numpy", beta, [1], [1], [1])
+    s.set({(0, 0): np.array([[7.0]], complex)}, "chi0_loc")
+    s.set({(0, 0): np.array([[2.0]], complex)}, "X0_loc")
+    s.set({(0, 0): np.array([[10.0]], complex)}, "X0_q")
+    s.calc("chi0")
+    out1 = s.get("chi0_q")
+    out1[(0, 0)][0, 0] = -12345.0   # mutate the returned array
+    out2 = s.get("chi0_q")
+    assert np.allclose(out2[(0, 0)], [[7.0 + (10.0 - 2.0) / beta]])  # unchanged

--- a/tests/python/non-mpi/solver/test_numpy_facade.py
+++ b/tests/python/non-mpi/solver/test_numpy_facade.py
@@ -20,3 +20,12 @@ def test_missing_input_reports_capital_X0_Loc():
     s.set({(0, 0): np.zeros((1, 1), complex), (1, 1): np.zeros((1, 1), complex)}, "X0_q")
     with pytest.raises(RuntimeError, match="'X0_Loc' must be set"):
         s.calc("chi0")
+
+def test_get_unknown_name_raises():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    with pytest.raises(RuntimeError, match="Invalid type"):
+        s.get("totally_bogus_name")
+
+def test_get_valid_uncomputed_name_returns_empty_dict():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    assert s.get("chi_q") == {}   # valid output name, not computed yet -> {}

--- a/tests/python/non-mpi/solver/test_numpy_facade.py
+++ b/tests/python/non-mpi/solver/test_numpy_facade.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+from chiq.solver import get_solver
+
+def _info(nb, nw, n_in):
+    return ([n_in * nw] * nb, [n_in] * (nb * nw), [n_in] * nb)
+
+def test_set_unknown_name_raises():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    with pytest.raises(RuntimeError, match="Invalid type"):
+        s.set({(0, 0): np.zeros((1, 1), complex)}, "nope")
+
+def test_get_before_calc_returns_empty_dict():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    assert s.get("chi0_q") == {}
+
+def test_missing_input_reports_capital_X0_Loc():
+    s = get_solver("numpy", 10.0, *_info(1, 2, 1))
+    s.set({(0, 0): np.zeros((1, 1), complex)}, "chi0_loc")
+    s.set({(0, 0): np.zeros((1, 1), complex), (1, 1): np.zeros((1, 1), complex)}, "X0_q")
+    with pytest.raises(RuntimeError, match="'X0_Loc' must be set"):
+        s.calc("chi0")

--- a/tests/python/non-mpi/solver/test_numpy_rpa.py
+++ b/tests/python/non-mpi/solver/test_numpy_rpa.py
@@ -1,0 +1,17 @@
+import numpy as np
+from chiq.solver.kernels import calc_rpa, calc_rrpa
+
+def test_rpa_zero_gamma_gives_chi0():
+    nb, nw, n_in, beta = 1, 1, 1, 1.0
+    chi0_q = {(0, 0): np.array([[2.0]], complex)}
+    gamma0 = {(0, 0): np.array([[0.0]], complex)}
+    out = calc_rpa({"chi0_q": chi0_q, "gamma0": gamma0}, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q_rpa"][(0, 0)], [[2.0]])
+
+def test_rrpa_when_chi0loc_equals_chiloc_gives_chi0q():
+    # U_eff = chi0_loc^-1 - chi_loc^-1 = 0 -> chi_q_rrpa = chi0_q
+    nb, nw, n_in, beta = 1, 1, 1, 1.0
+    same = {(0, 0): np.array([[3.0]], complex)}
+    chi0_q = {(0, 0): np.array([[2.0]], complex)}
+    out = calc_rrpa({"chi0_loc": same, "chi_loc": same, "chi0_q": chi0_q}, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q_rrpa"][(0, 0)], [[2.0]])

--- a/tests/python/non-mpi/solver/test_numpy_scl.py
+++ b/tests/python/non-mpi/solver/test_numpy_scl.py
@@ -1,0 +1,13 @@
+import numpy as np
+from chiq.solver.kernels import calc_scl
+
+def test_scl_when_X0q_equals_X0loc_gives_phisum_squared():
+    # Lambda_q = X0_loc^-1 - X0_q^-1 = 0 -> lambda_q = 0
+    # chi_q_scl = Phi_sum * I^-1 * Phi_sum = Phi_sum @ Phi_sum
+    nb, nw, n_in, beta = 1, 2, 1, 1.0
+    X0 = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[2.0]], complex)}
+    Phi = {(0, 0): np.array([[1.0]], complex), (1, 1): np.array([[1.0]], complex)}  # B-type
+    Phi_sum = {(0, 0): np.array([[3.0]], complex)}  # C-type
+    out = calc_scl({"X0_q": X0, "X0_loc": X0, "Phi": Phi, "Phi_sum": Phi_sum}, beta, nb, nw, n_in)
+    assert np.allclose(out["chi_q_scl"][(0, 0)], [[9.0]])   # 3*3
+    assert np.allclose(out["I_q_scl"][(0, 0)], [[0.0]])     # Phi_sum^-1 * 0 * Phi_sum^-1


### PR DESCRIPTION
## Summary

Introduces a **`backend = "cpp" | "numpy" | "cupy"`** switch for the BSE solver — the foundation for the planned GPU (CuPy) and IR-basis work. The strategy (agreed during design) is *not* to CUDA-ify the C++, but to reimplement the solver in Python against an injectable array module, since the data already lives as `dict{(block,block): ndarray}` and the operations are dense block linear algebra.

**Default behavior is unchanged**: the `cpp` backend is the default and the existing pybind path is untouched; all pre-existing tests still pass.

## What's in this PR (Phase 0)

- **`chiq.solver` subpackage** (`layout.py` / `kernels.py` / `base.py` / `cpp.py` / `numpy.py` / `cupy.py` / `__init__.py`):
  - `layout.py` — block-matrix algebra reproducing the C++ `src/block_matrix.hpp` / `src/bse.hpp` conventions (A/B/C layouts, `sumfreq_a/b`, `convert_a2b/b2a`, connected-component `block_inverse` with fill-in, structural-key `matmul`).
  - `kernels.py` — the five calculations (`chi0`, `bse`, `rpa`, `rrpa`, `scl`), transcribed operation-for-operation from `bse.hpp`.
  - `CppSolver` (thin wrapper over the existing `bse_solver` module), `NumpySolver` (runs the kernels; matches C++ error semantics: empty-dict `get`, `'X0_Loc'`/`'Phi_Sum'` error strings, shared `I_q`/`I_q_scl` slot, owned-copy `set`/`get`), `CupySolver` (skeleton, raises a clear "not enabled" error), and a `get_solver` factory.
  - Backend selected via `[chiq_main] backend = "..."` in the TOML (default `cpp`).
- **Build fix**: `CMAKE_CXX_STANDARD` 11 -> 17 (modern Eigen 3.4+ requires >= C++14).
- **Tests**: layout unit tests, per-kernel tests, a **cpp<->numpy agreement suite** (11 parametrizations across all 5 calc types on random well-conditioned inputs at `rtol=1e-8`, incl. `I_q`/`I_q_scl`), a numpy **end-to-end** run through `chiq_main`, plus factory/cupy/mutation-isolation tests. Full non-MPI suite: **66 passing**.

## Validation

The NumPy backend is proven numerically equivalent to the C++ oracle (~1e-16) across every calc type, including outputs the driver reads. The agreement gate was independently verified to fail on real perturbations and operand-order swaps.

## Scope / follow-ups (separate plans)

- pip packaging (scikit-build-core, `_bse_solver` rename, entry points, `bse`/`bse_solver` shims, Python-floor bump, `toml`/`scipy` deps) — deferred.
- Enable/tune the CuPy GPU backend; sparse-ir in the chi0 evaluation; IR/DLR compression of the BSE frequency sum.

Design spec and implementation plan are under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuYETP4Eu2XTZ5ch8UZfXk